### PR TITLE
rename local-variable 'L' to 'luaVMInstance'

### DIFF
--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -315,7 +315,6 @@ func (l *LuaPlugin) Label(version string) string {
 }
 
 func NewLuaPlugin(content string, osType util.OSType, archType util.ArchType) (*LuaPlugin, error) {
-	//rename local-variable 'L' to 'luaVMInstance'.make it more intelligible
 	luaVMInstance := lua.NewState()
 	lua_module.Preload(luaVMInstance)
 	if err := luaVMInstance.DoString(content); err != nil {
@@ -326,12 +325,12 @@ func NewLuaPlugin(content string, osType util.OSType, archType util.ArchType) (*
 	luaVMInstance.SetGlobal(OsType, lua.LString(osType))
 	luaVMInstance.SetGlobal(ArchType, lua.LString(archType))
 
-	pluginOjb := luaVMInstance.GetGlobal(LuaPluginObjKey)
-	if pluginOjb.Type() == lua.LTNil {
+	pluginObj := luaVMInstance.GetGlobal(LuaPluginObjKey)
+	if pluginObj.Type() == lua.LTNil {
 		return nil, fmt.Errorf("plugin object not found")
 	}
 
-	PLUGIN := pluginOjb.(*lua.LTable)
+	PLUGIN := pluginObj.(*lua.LTable)
 
 	source := &LuaPlugin{
 		state:     luaVMInstance,

--- a/sdk/plugin.go
+++ b/sdk/plugin.go
@@ -315,17 +315,18 @@ func (l *LuaPlugin) Label(version string) string {
 }
 
 func NewLuaPlugin(content string, osType util.OSType, archType util.ArchType) (*LuaPlugin, error) {
-	L := lua.NewState()
-	lua_module.Preload(L)
-	if err := L.DoString(content); err != nil {
+	//rename local-variable 'L' to 'luaVMInstance'.make it more intelligible
+	luaVMInstance := lua.NewState()
+	lua_module.Preload(luaVMInstance)
+	if err := luaVMInstance.DoString(content); err != nil {
 		return nil, err
 	}
 
 	// set OS_TYPE and ARCH_TYPE
-	L.SetGlobal(OsType, lua.LString(osType))
-	L.SetGlobal(ArchType, lua.LString(archType))
+	luaVMInstance.SetGlobal(OsType, lua.LString(osType))
+	luaVMInstance.SetGlobal(ArchType, lua.LString(archType))
 
-	pluginOjb := L.GetGlobal(LuaPluginObjKey)
+	pluginOjb := luaVMInstance.GetGlobal(LuaPluginObjKey)
 	if pluginOjb.Type() == lua.LTNil {
 		return nil, fmt.Errorf("plugin object not found")
 	}
@@ -333,7 +334,7 @@ func NewLuaPlugin(content string, osType util.OSType, archType util.ArchType) (*
 	PLUGIN := pluginOjb.(*lua.LTable)
 
 	source := &LuaPlugin{
-		state:     L,
+		state:     luaVMInstance,
 		pluginObj: PLUGIN,
 	}
 


### PR DESCRIPTION
file 'plugin.go' line 318 instance a local-variable which named 'L':which is a Lua VM 's instance.It's not a particularly clear naming so I rename 'L' to 'luaVMInstance'.Intended to make people more accurate to know its role