### PR TITLE
add a json flag in `vfox env` subcommand

### DIFF
--- a/cmd/commands/env.go
+++ b/cmd/commands/env.go
@@ -49,50 +49,50 @@ var Env = &cli.Command{
 }
 
 func envCmd(ctx *cli.Context) error {
-  if ctx.IsSet("json") {
-    type SDKs map[string]map[string]string
-    data := struct {
-      IsHookEnv bool     `json:"is_hook_env"`
-      Paths []string     `json:"paths"`
-      SDKs  SDKs         `json:"sdks"`
-    }{
-      IsHookEnv: env.IsHookEnv(),
-      Paths: []string{},
-      SDKs: make(SDKs),
-    }
+	if ctx.IsSet("json") {
+		type SDKs map[string]map[string]string
+		data := struct {
+			IsHookEnv bool     `json:"is_hook_env"`
+			Paths     []string `json:"paths"`
+			SDKs      SDKs     `json:"sdks"`
+		}{
+			IsHookEnv: env.IsHookEnv(),
+			Paths:     []string{},
+			SDKs:      make(SDKs),
+		}
 		manager := internal.NewSdkManager()
 		defer manager.Close()
 		allSdk, loadErr := manager.LoadAllSdk()
-    if loadErr != nil {
-      return loadErr
-    }
+		if loadErr != nil {
+			return loadErr
+		}
 		for name, s := range allSdk {
 			current := s.Current()
 			if current != "" {
-        envs, envErr := s.EnvKeys(current)
-        if envErr != nil {
-          return envErr
-        }
-        newEnv := make(map[string]string)
-        for k, v := range envs {
-          if k == "PATH" {
-            data.Paths = append(data.Paths, *v)
-          } else {
-            newEnv[k] = *v
-          }
-        }
-        if len(newEnv) > 0 {
-          data.SDKs[name] = newEnv
-        }
+				envs, envErr := s.EnvKeys(current)
+				if envErr != nil {
+					return envErr
+				}
+				newEnv := make(map[string]string)
+				for k, v := range envs {
+					if k == "PATH" {
+						data.Paths = append(data.Paths, *v)
+					} else {
+						newEnv[k] = *v
+					}
+				}
+				if len(newEnv) > 0 {
+					data.SDKs[name] = newEnv
+				}
 			}
 		}
-    jsonData, err := json.Marshal(data)
-    if err != nil {
-      return err
-    }
-    fmt.Println(string(jsonData))
-    return nil
-  } else if ctx.IsSet("cleanup") {
+		jsonData, err := json.Marshal(data)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(jsonData))
+		return nil
+	} else if ctx.IsSet("cleanup") {
 		manager := internal.NewSdkManager()
 		defer manager.Close()
 		// Clean up the old temp files, before today.

--- a/cmd/commands/env.go
+++ b/cmd/commands/env.go
@@ -17,9 +17,11 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/urfave/cli/v2"
 	"github.com/version-fox/vfox/internal"
+	"github.com/version-fox/vfox/internal/env"
 	"github.com/version-fox/vfox/internal/shell"
 )
 
@@ -37,12 +39,60 @@ var Env = &cli.Command{
 			Aliases: []string{"c"},
 			Usage:   "cleanup temp file",
 		},
+		&cli.BoolFlag{
+			Name:    "json",
+			Aliases: []string{"j"},
+			Usage:   "get envs as json",
+		},
 	},
 	Action: envCmd,
 }
 
 func envCmd(ctx *cli.Context) error {
-	if ctx.IsSet("cleanup") {
+  if ctx.IsSet("json") {
+    type SDKs map[string]map[string]string
+    data := struct {
+      IsHookEnv bool     `json:"is_hook_env"`
+      Paths []string     `json:"paths"`
+      SDKs  SDKs         `json:"sdks"`
+    }{
+      IsHookEnv: env.IsHookEnv(),
+      Paths: []string{},
+      SDKs: make(SDKs),
+    }
+		manager := internal.NewSdkManager()
+		defer manager.Close()
+		allSdk, loadErr := manager.LoadAllSdk()
+    if loadErr != nil {
+      return loadErr
+    }
+		for name, s := range allSdk {
+			current := s.Current()
+			if current != "" {
+        envs, envErr := s.EnvKeys(current)
+        if envErr != nil {
+          return envErr
+        }
+        newEnv := make(map[string]string)
+        for k, v := range envs {
+          if k == "PATH" {
+            data.Paths = append(data.Paths, *v)
+          } else {
+            newEnv[k] = *v
+          }
+        }
+        if len(newEnv) > 0 {
+          data.SDKs[name] = newEnv
+        }
+			}
+		}
+    jsonData, err := json.Marshal(data)
+    if err != nil {
+      return err
+    }
+    fmt.Println(string(jsonData))
+    return nil
+  } else if ctx.IsSet("cleanup") {
 		manager := internal.NewSdkManager()
 		defer manager.Close()
 		// Clean up the old temp files, before today.


### PR DESCRIPTION
hello, I have added a flag to get the paths in JSON format.

use cases:

```sh
vfox_data=$(vfox env --json)

for path in $(echo "$vfox_data" | jq -r '.paths[]'); do
    export PATH="$PATH:$path"
done

for sdk_name in $(echo "$vfox_data" | jq -r '.sdks | keys_unsorted[]'); do
    for var_name in $(echo "$vfox_data" | jq -r ".sdks.$sdk_name | keys_unsorted[]"); do
        export "$var_name"=$(echo "$vfox_data" | jq -r ".sdks.$sdk_name.\"$var_name\"")
    done
done
```

![03-01-24_08:54:23](https://github.com/version-fox/vfox/assets/55039048/3046428b-109d-479a-8e84-4afda28f4366)

![03-01-24_08:47:57](https://github.com/version-fox/vfox/assets/55039048/50c47795-4b80-4bcd-8cdb-f254d77ca2ab)

![03-01-24_08:46:51](https://github.com/version-fox/vfox/assets/55039048/0d8f2424-6877-465e-9db9-22e5e74c6690)

