### PR TITLE
don't defer Record.Save

### DIFF
--- a/internal/sdk.go
+++ b/internal/sdk.go
@@ -263,7 +263,10 @@ func (b *Sdk) Use(version Version, scope UseScope) error {
 		}
 	}
 	b.sdkManager.Record.Add(b.Plugin.Filename, string(version))
-	defer b.sdkManager.Record.Save()
+	err := b.sdkManager.Record.Save()
+	if err != nil {
+		return err
+	}
 	pterm.Printf("Now using %s.\n", pterm.LightGreen(label))
 	if !env.IsHookEnv() {
 		return shell.GetProcess().Open(os.Getppid())


### PR DESCRIPTION
don't defer `Record.Save()`, because in case the block is entered:
```go
if !env.IsHookEnv() {
    return shell.GetProcess().Open(os.Getppid())
}
```
an early return is performed, and the function is not finished executing, therefore the defer is never called.