### PR TITLE
refactor: Refactor EnvKeys to make configuring multiple PATHs smoother

### DIFF
--- a/cmd/commands/activate.go
+++ b/cmd/commands/activate.go
@@ -47,15 +47,19 @@ func activateCmd(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	envKeys[env.HookFlag] = &name
+	exportEnvs := make(env.Vars)
+	for k, v := range envKeys.Variables {
+		exportEnvs[k] = v
+	}
+
+	exportEnvs[env.HookFlag] = &name
 	originPath := os.Getenv("PATH")
-	envKeys[env.PathFlag] = &originPath
+	exportEnvs[env.PathFlag] = &originPath
 
-	sdkPaths := envKeys["PATH"]
-	if sdkPaths != nil {
-		paths := manager.EnvManager.Paths([]string{*sdkPaths, originPath})
-
-		envKeys["PATH"] = &paths
+	sdkPaths := envKeys.Paths
+	if len(sdkPaths) != 0 {
+		paths := manager.EnvManager.Paths(append(sdkPaths[:], originPath))
+		exportEnvs["PATH"] = &paths
 	}
 
 	path := manager.PathMeta.ExecutablePath
@@ -64,7 +68,7 @@ func activateCmd(ctx *cli.Context) error {
 	if s == nil {
 		return fmt.Errorf("unknow target shell %s", name)
 	}
-	exportStr := s.Export(envKeys)
+	exportStr := s.Export(exportEnvs)
 	str, err := s.Activate()
 	if err != nil {
 		return err

--- a/docs/plugins/create/howto.md
+++ b/docs/plugins/create/howto.md
@@ -125,9 +125,14 @@ function PLUGIN:EnvKeys(ctx)
             key = "JAVA_HOME",
             value = mainPath
         },
+        --- NOTE: If you need to set multiple PATH paths, just pass multiple PATHs, vfox will automatically deduplicate and set them in the order of configuration
         {
             key = "PATH",
             value = mainPath .. "/bin"
+        },
+        {
+            key = "PATH",
+            value = mainPath .. "/bin2"
         }
     }
 end

--- a/docs/zh-hans/plugins/create/howto.md
+++ b/docs/zh-hans/plugins/create/howto.md
@@ -119,9 +119,14 @@ function PLUGIN:EnvKeys(ctx)
             key = "JAVA_HOME",
             value = mainPath
         },
+        --- 注意, 如果需要设置多个PATH路径, 只需要传递多个PATH即可,vfox将会自动去重并按配置顺序设置
         {
             key = "PATH",
             value = mainPath .. "/bin"
+        },
+        {
+            key = "PATH",
+            value = mainPath .. "/bin2"
         }
     }
 end

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -22,11 +22,21 @@ import (
 
 type Manager interface {
 	Flush() error
-	Load(key, value string) error
+	Load(envs *Envs) error
 	Get(key string) (string, bool)
-	Remove(key string) error
+	Remove(envs *Envs) error
 	Paths(paths []string) string
 	io.Closer
 }
 
-type Envs map[string]*string
+// Vars is a map of environment variables
+type Vars map[string]*string
+
+// Paths is a slice of PATH.
+type Paths []string
+
+// Envs is a struct that contains environment variables and PATH.
+type Envs struct {
+	Variables Vars
+	Paths     Paths
+}

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -164,17 +164,20 @@ func TestPlugin(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		javaHome := keys["JAVA_HOME"]
+		javaHome := keys.Variables["JAVA_HOME"]
 		if *javaHome == "" {
 			t.Errorf("expected JAVA_HOME to be set, got '%s'", *javaHome)
 		}
-		path := keys["PATH"]
-		if *path == "" {
-			t.Errorf("expected PATH to be set, got '%s'", *path)
+		path := keys.Paths
+		if len(path) != 2 {
+			t.Errorf("expected 2 paths, got %d", len(path))
 		}
 
-		if !strings.HasSuffix(*path, "/bin") {
-			t.Errorf("expected PATH to end with '/bin', got '%s'", *path)
+		if !strings.HasSuffix(path[0], "/bin") {
+			t.Errorf("expected PATH to end with '/bin', got '%s'", path[0])
+		}
+		if !strings.HasSuffix(path[1], "/bin2") {
+			t.Errorf("expected PATH to end with '/bin', got '%s'", path[1])
 		}
 	})
 

--- a/internal/sdk.go
+++ b/internal/sdk.go
@@ -213,7 +213,7 @@ func (b *Sdk) Available() ([]*Package, error) {
 	return b.Plugin.Available()
 }
 
-func (b *Sdk) EnvKeys(version Version) (env.Envs, error) {
+func (b *Sdk) EnvKeys(version Version) (*env.Envs, error) {
 	label := b.label(version)
 	if !b.checkExists(version) {
 		return nil, fmt.Errorf("%s is not installed", label)
@@ -280,10 +280,8 @@ func (b *Sdk) Use(version Version, scope UseScope) error {
 
 		b.clearCurrentEnvConfig()
 
-		for key, value := range keys {
-			if err = b.sdkManager.EnvManager.Load(key, *value); err != nil {
-				return err
-			}
+		if err = b.sdkManager.EnvManager.Load(keys); err != nil {
+			return err
 		}
 		err = b.sdkManager.EnvManager.Flush()
 		if err != nil {
@@ -360,13 +358,7 @@ func (b *Sdk) clearEnvConfig(version Version) {
 		return
 	}
 	envManager := b.sdkManager.EnvManager
-	for k, v := range envKV {
-		if k == "PATH" {
-			_ = envManager.Remove(*v)
-		} else {
-			_ = envManager.Remove(k)
-		}
-	}
+	_ = envManager.Remove(envKV)
 }
 
 func (b *Sdk) getLocalSdkPackage(version Version) (*Package, error) {

--- a/internal/shell/bash.go
+++ b/internal/shell/bash.go
@@ -51,7 +51,7 @@ func (b bash) Activate() (string, error) {
 	return bashHook, nil
 }
 
-func (b bash) Export(envs env.Envs) (out string) {
+func (b bash) Export(envs env.Vars) (out string) {
 	for key, value := range envs {
 		if value == nil {
 			out += b.unset(key)

--- a/internal/shell/fish.go
+++ b/internal/shell/fish.go
@@ -64,7 +64,7 @@ func (sh fish) Activate() (string, error) {
 	return fishHook, nil
 }
 
-func (sh fish) Export(e env.Envs) (out string) {
+func (sh fish) Export(e env.Vars) (out string) {
 	for key, value := range e {
 		if value == nil {
 			out += sh.unset(key)

--- a/internal/shell/powershell.go
+++ b/internal/shell/powershell.go
@@ -48,7 +48,7 @@ func (sh pwsh) Activate() (string, error) {
 	return hook, nil
 }
 
-func (sh pwsh) Export(e env.Envs) (out string) {
+func (sh pwsh) Export(e env.Vars) (out string) {
 	for key, value := range e {
 		if value == nil {
 			out += sh.unset(key)

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -23,7 +23,7 @@ import (
 
 type Shell interface {
 	Activate() (string, error)
-	Export(envs env.Envs) string
+	Export(envs env.Vars) string
 }
 
 func NewShell(name string) Shell {

--- a/internal/shell/zsh.go
+++ b/internal/shell/zsh.go
@@ -47,7 +47,7 @@ func (z zsh) Activate() (string, error) {
 	return zshHook, nil
 }
 
-func (z zsh) Export(envs env.Envs) (out string) {
+func (z zsh) Export(envs env.Vars) (out string) {
 	for key, value := range envs {
 		if value == nil {
 			out += z.unset(key)

--- a/internal/testdata/plugins/java.lua
+++ b/internal/testdata/plugins/java.lua
@@ -118,6 +118,10 @@ function PLUGIN:EnvKeys(ctx)
         {
             key = "PATH",
             value = mainPath .. "/bin"
+        },
+        {
+            key = "PATH",
+            value = mainPath .. "/bin2"
         }
     }
 end

--- a/template.lua
+++ b/template.lua
@@ -122,8 +122,14 @@ function PLUGIN:EnvKeys(ctx)
         {
             key = "PATH",
             value = mainPath .. "/bin"
-        }
+        },
+        {
+            key = "PATH",
+            value = mainPath .. "/bin2"
+        },
+
     }
+
 end
 
 --- When user invoke `use` command, this function will be called to get the


### PR DESCRIPTION
When the plugin configures multiple PATHs, there is no need to care about the specific OS delimiter, be it ; or :, just pass multiple PATHs and vfox will configure and de-duplicate them in order.


like this:

https://github.com/version-fox/version-fox-plugins/blob/9c8547364977506e2fdbe1b9ab83dc9b44d95c30/python/python.lua#L189-L192

