### PR TITLE
fix(powershell): fix powershell prompt

### DIFF
--- a/internal/shell/powershell.go
+++ b/internal/shell/powershell.go
@@ -33,12 +33,13 @@ const hook = `
 {{.EnvContent}}
 
 $__VFOX_PID=$pid;
+$originalPrompt = & $function:prompt
 function prompt {
     $export = &"{{.SelfPath}}" env -s pwsh;
     if ($export) {
-      Invoke-Expression -Command $export;
+		Invoke-Expression -Command $export;
     }
-	return "PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) ";
+    return $originalPrompt;
 }
 
 Register-EngineEvent -SourceIdentifier PowerShell.Exiting -SupportEvent -Action {

--- a/internal/shell/powershell.go
+++ b/internal/shell/powershell.go
@@ -33,7 +33,7 @@ const hook = `
 {{.EnvContent}}
 
 $__VFOX_PID=$pid;
-$originalPrompt = & $function:prompt
+$originalPrompt = $function:prompt;
 function prompt {
     $export = &"{{.SelfPath}}" env -s pwsh;
     if ($export) {

--- a/internal/shell/powershell.go
+++ b/internal/shell/powershell.go
@@ -39,7 +39,7 @@ function prompt {
     if ($export) {
 		Invoke-Expression -Command $export;
     }
-    return $originalPrompt;
+    &$originalPrompt;
 }
 
 Register-EngineEvent -SourceIdentifier PowerShell.Exiting -SupportEvent -Action {


### PR DESCRIPTION
1. Fix powershell prompt has been replaced, just using the original prompt.
2. 获取到原prompt后，先尝试匹配是否是默认[prompt](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_prompts?view=powershell-7.4)，如果是则适用默认方式生成prompt，否则适用自定义方式。
3. 为什么没有直接使用原始prompt？
`"PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) ";
` 这里的`>`似乎会变化，如果直接返回原始prompt就出现不一致。