### PR TITLE
fix(powershell): fix powershell env encoding

### DIFF
--- a/internal/shell/powershell.go
+++ b/internal/shell/powershell.go
@@ -39,6 +39,7 @@ Due to a bug in PowerShell, we have to cleanup first when the shell open.
 
 $__VFOX_PID=$pid;
 $originalPrompt = $function:prompt;
+$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = [Text.UTF8Encoding]::UTF8;
 
 function prompt {
     $export = &"{{.SelfPath}}" env -s pwsh;


### PR DESCRIPTION
1. Fix powershell env encoding.
2. Reference https://stackoverflow.com/questions/61112217/how-to-put-envlc-all-c-utf-8-on-profile-file-of-powershell

fix #116 