### PR TITLE
Fixed the bug where the `search` did not stop listening after being interrupted by Ctrl+C

### DIFF
--- a/cmd/commands/search.go
+++ b/cmd/commands/search.go
@@ -97,5 +97,8 @@ func searchCmd(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("select version error: %w", err)
 	}
+	if version == nil {
+		return nil
+	}
 	return source.Install(internal.Version(version.Key))
 }

--- a/internal/printer/select.go
+++ b/internal/printer/select.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"github.com/lithammer/fuzzysearch/fuzzy"
 	"github.com/pterm/pterm"
-	"os"
+	"github.com/version-fox/vfox/internal/logger"
 	"sort"
 	"strings"
 )
@@ -184,8 +184,8 @@ func (s *PageKVSelect) Show() (*KV, error) {
 			area.Update(s.renderSelect())
 		case keys.CtrlC:
 			s.result = nil
-			os.Exit(0)
-			return true, fmt.Errorf("keyboard interrupt")
+			logger.Info("Ctrl+C pressed, program stopped.")
+			return true, nil
 		case keys.Down:
 			s.changeIndex(1)
 			area.Update(s.renderSelect())


### PR DESCRIPTION
fixes #131