### PR TITLE
Refactor: Fetch plugin from Registry &  Allowing the switching of registry addresses.

### DIFF
--- a/cmd/commands/add.go
+++ b/cmd/commands/add.go
@@ -38,6 +38,7 @@ var Add = &cli.Command{
 	Action: addCmd,
 }
 
+// addCmd is the command to add a plugin of sdk
 func addCmd(ctx *cli.Context) error {
 	manager := internal.NewSdkManagerWithSource()
 	defer manager.Close()

--- a/cmd/commands/available.go
+++ b/cmd/commands/available.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/urfave/cli/v2"
 	"github.com/version-fox/vfox/internal"
+	"strings"
 )
 
 var Available = &cli.Command{
@@ -31,29 +32,20 @@ var Available = &cli.Command{
 func availableCmd(ctx *cli.Context) error {
 	manager := internal.NewSdkManagerWithSource()
 	defer manager.Close()
-	categoryName := ctx.Args().First()
-	categories, err := manager.Available()
+	//categoryName := ctx.Args().First()
+	available, err := manager.Available()
 	if err != nil {
 		return err
 	}
 	data := pterm.TableData{
-		{"NAME", "VERSION", "AUTHOR", "DESCRIPTION"},
+		{"NAME", "OFFICIAL", "HOMEPAGE", "DESCRIPTION"},
 	}
-	for _, category := range categories {
-		if len(categoryName) > 0 {
-			if categoryName != category.Name {
-				continue
-			}
+	for _, item := range available {
+		official := pterm.LightRed("NO")
+		if strings.HasPrefix(item.Homepage, "https://github.com/version-fox/") {
+			official = pterm.LightGreen("YES")
 		}
-		for _, p := range category.Plugins {
-			desc := p.Desc
-			if len(desc) == 0 {
-				desc = "-"
-			} else if len(desc) > 100 {
-				desc = desc[:100] + "..."
-			}
-			data = append(data, []string{category.Name + "/" + p.Filename, p.Version, p.Author, desc})
-		}
+		data = append(data, []string{item.Name, official, item.Homepage, item.Desc})
 	}
 
 	_ = pterm.DefaultTable.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,16 +24,18 @@ import (
 )
 
 type Config struct {
-	Proxy   *Proxy   `yaml:"proxy"`
-	Storage *Storage `yaml:"storage"`
+	Proxy    *Proxy    `yaml:"proxy"`
+	Storage  *Storage  `yaml:"storage"`
+	Registry *Registry `yaml:"registry"`
 }
 
 const filename = "config.yaml"
 
 var (
 	defaultConfig = &Config{
-		Proxy:   EmptyProxy,
-		Storage: EmptyStorage,
+		Proxy:    EmptyProxy,
+		Storage:  EmptyStorage,
+		Registry: EmptyRegistry,
 	}
 )
 
@@ -59,6 +61,9 @@ func NewConfigWithPath(p string) (*Config, error) {
 	}
 	if config.Storage == nil {
 		config.Storage = EmptyStorage
+	}
+	if config.Registry == nil {
+		config.Registry = EmptyRegistry
 	}
 	return config, nil
 

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -4,3 +4,6 @@ proxy:
 
 storage:
   sdkPath: /tmp
+
+registry:
+  address: "https://cdn.jsdelivr.net/gh/version-fox/vfox-plugins/plugins"

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -1,0 +1,25 @@
+/*
+ *    Copyright 2024 Han Li and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package config
+
+type Registry struct {
+	Address string `yaml:"address"`
+}
+
+var EmptyRegistry = &Registry{
+	Address: "",
+}

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -122,9 +122,9 @@ func (m *Manager) LoadAllSdk() (map[string]*Sdk, error) {
 		} else {
 			continue
 		}
-		source, err := NewLuaPlugin(filepath.Dir(path), m)
+		source, err := NewLuaPlugin(path, m)
 		if err != nil {
-			pterm.Printf("Failed to load %s plugin, err: %s\n", filepath.Dir(path), err)
+			pterm.Printf("Failed to load %s plugin, err: %s\n", path, err)
 			continue
 		}
 		sdk, _ := NewSdk(m, source)
@@ -175,7 +175,7 @@ func (m *Manager) Update(pluginName string) error {
 	if err != nil {
 		return fmt.Errorf("fetch plugin failed, err: %w", err)
 	}
-	source, err := NewLegacyLuaPlugin(content, updateUrl, m)
+	source, err := NewLuaPlugin(updateUrl, m)
 	if err != nil {
 		return fmt.Errorf("check %s plugin failed, err: %w", updateUrl, err)
 	}
@@ -238,7 +238,7 @@ func (m *Manager) Add(pluginName, url, alias string) error {
 		return fmt.Errorf("failed to load plugin: %w", err)
 	}
 	pterm.Println("Checking plugin...")
-	source, err := NewLegacyLuaPlugin(content, url, m)
+	source, err := NewLuaPlugin(url, m)
 	if err != nil {
 		return fmt.Errorf("check plugin error: %w", err)
 	}

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -326,6 +326,11 @@ func (m *Manager) Add(pluginName, url, alias string) error {
 			pname = strings.Split(pluginName, "/")[1]
 		}
 
+		installPath := filepath.Join(m.PathMeta.PluginPath, pname)
+		if util.FileExists(installPath) {
+			return fmt.Errorf("plugin %s already exists", pname)
+		}
+
 		pluginManifest, err := m.fetchPluginManifest(m.GetRegistryAddress(pname + ".json"))
 		if err != nil {
 			return err

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -18,8 +18,11 @@ package internal
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"github.com/version-fox/vfox/internal/logger"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -34,8 +37,11 @@ import (
 )
 
 const (
-	pluginIndexUrl      = "https://version-fox.github.io/version-fox-plugins/"
 	cleanupFlagFilename = ".cleanup"
+)
+
+var (
+	manifestNotFound = errors.New("manifest not found")
 )
 
 type Arg struct {
@@ -104,8 +110,8 @@ func (m *Manager) LoadAllSdk() (map[string]*Sdk, error) {
 	sdkMap := make(map[string]*Sdk)
 	for _, d := range dir {
 		sdkName := d.Name()
-		path := filepath.Join(m.PathMeta.PluginPath, sdkName, "main.lua")
-		if util.FileExists(path) {
+		path := filepath.Join(m.PathMeta.PluginPath, sdkName)
+		if d.IsDir() {
 		} else if strings.HasSuffix(sdkName, ".lua") {
 			// FIXME !!! This snippet will be removed in a later version
 			// rename old plugin path to new plugin path
@@ -124,7 +130,7 @@ func (m *Manager) LoadAllSdk() (map[string]*Sdk, error) {
 		}
 		source, err := NewLuaPlugin(path, m)
 		if err != nil {
-			pterm.Printf("Failed to load %s plugin, err: %s\n", path, err)
+			pterm.Printf("Failed to load %s plugin, err: %s\n", filepath.Dir(path), err)
 			continue
 		}
 		sdk, _ := NewSdk(m, source)
@@ -166,111 +172,265 @@ func (m *Manager) Update(pluginName string) error {
 	if err != nil {
 		return fmt.Errorf("%s plugin not installed", pluginName)
 	}
-	updateUrl := sdk.Plugin.UpdateUrl
-	if updateUrl == "" {
-		return fmt.Errorf("%s plugin not support update", pluginName)
+	pterm.Printf("Checking plugin manifest...\n")
+	// Update search priority: updateUrl > registry > manifestUrl
+	downloadUrl := sdk.Plugin.UpdateUrl
+	if sdk.Plugin.UpdateUrl == "" {
+		address := m.GetRegistryAddress(sdk.Plugin.Name + ".json")
+		logger.Debugf("Fetching plugin %s from %s...\n", pluginName, address)
+		registryManifest, err := m.fetchPluginManifest(address)
+		if err != nil {
+			if errors.Is(err, manifestNotFound) {
+				if sdk.Plugin.ManifestUrl != "" {
+					logger.Debugf("Fetching plugin %s from %s...\n", pluginName, sdk.Plugin.ManifestUrl)
+					du, err := m.fetchPluginManifest(sdk.Plugin.ManifestUrl)
+					if err != nil {
+						return err
+					}
+					if util.CompareVersion(du.Version, sdk.Plugin.Version) <= 0 {
+						pterm.Printf("%s is already the latest version\n", pterm.LightBlue(pluginName))
+						return nil
+					}
+					downloadUrl = du.DownloadUrl
+				} else {
+					return fmt.Errorf("%s plugin not support update", pluginName)
+				}
+			}
+			return err
+		}
+		if util.CompareVersion(registryManifest.Version, sdk.Plugin.Version) <= 0 {
+			pterm.Printf("%s is already the latest version\n", pterm.LightBlue(pluginName))
+			return nil
+		}
+		downloadUrl = registryManifest.DownloadUrl
+
 	}
-	pterm.Printf("Checking %s plugin...\n", updateUrl)
-	content, err := m.loadLuaFromFileOrUrl(updateUrl)
+	tempPlugin, err := m.installPluginToTemp(downloadUrl)
 	if err != nil {
-		return fmt.Errorf("fetch plugin failed, err: %w", err)
+		return err
 	}
-	source, err := NewLuaPlugin(updateUrl, m)
-	if err != nil {
-		return fmt.Errorf("check %s plugin failed, err: %w", updateUrl, err)
+	defer func() {
+		_ = os.RemoveAll(tempPlugin.Path)
+		tempPlugin.Close()
+	}()
+	pterm.Println("Comparing plugin version...")
+	if util.CompareVersion(tempPlugin.Version, sdk.Plugin.Version) <= 0 {
+		pterm.Printf("%s is already the latest version\n", pterm.LightBlue(pluginName))
+		return nil
 	}
 	success := false
-	backupPath := sdk.Plugin.Path + ".bak"
-	err = util.CopyFile(sdk.Plugin.Path, backupPath)
-	if err != nil {
-		return fmt.Errorf("backup %s plugin failed, err: %w", updateUrl, err)
+	backupPath := sdk.Plugin.Path + "-bak"
+	logger.Debugf("Backup %s plugin to %s \n", sdk.Plugin.Path, backupPath)
+	if err = os.Rename(sdk.Plugin.Path, backupPath); err != nil {
+		return fmt.Errorf("backup %s plugin failed, err: %w", sdk.Plugin.Path, err)
 	}
 	defer func() {
 		if success {
-			_ = os.Remove(backupPath)
+			_ = os.RemoveAll(backupPath)
 		} else {
 			_ = os.Rename(backupPath, sdk.Plugin.Path)
 		}
 	}()
-	pterm.Println("Checking plugin version...")
-	if util.CompareVersion(source.Version, sdk.Plugin.Version) <= 0 {
-		success = true
-		pterm.Printf("the plugin is already the latest version")
-		return nil
-	}
-	err = os.WriteFile(sdk.Plugin.Path, []byte(content), 0644)
-	if err != nil {
-		return fmt.Errorf("update %s plugin failed: %w", updateUrl, err)
+	if err = os.Rename(tempPlugin.Path, sdk.Plugin.Path); err != nil {
+		return fmt.Errorf("update %s plugin failed, err: %w", pluginName, err)
 	}
 	success = true
-	pterm.Printf("Update %s plugin successfully! version: %s \n", pterm.LightGreen(pluginName), pterm.LightBlue(source.Version))
+	// print some notes if there are
+	if len(tempPlugin.Notes) != 0 {
+		fmt.Println(pterm.LightYellow("Notes:"))
+		for _, note := range tempPlugin.Notes {
+			fmt.Println("  -", note)
+		}
+	}
+	pterm.Printf("Update %s plugin successfully! version: %s \n", pterm.LightGreen(pluginName), pterm.LightBlue(tempPlugin.Version))
+
 	return nil
 }
 
+// fetchPluginManifest fetch plugin from registry by manifest url
+func (m *Manager) fetchPluginManifest(url string) (*RegistryPluginManifest, error) {
+	fmt.Println("Fetching plugin manifest...")
+	resp, err := m.httpClient().Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetch manifest error: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, manifestNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch manifest error, status code: %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("fetch manfiest error: %w", err)
+	}
+	var plugin RegistryPluginManifest
+	if err = json.Unmarshal(body, &plugin); err != nil {
+		return nil, fmt.Errorf("parse plugin error: %w", err)
+	}
+	logger.Debugf("Manifest found, name: %s, version: %s,  downloadUrl: %s \n", plugin.Name, plugin.Version, plugin.DownloadUrl)
+
+	// Check if the plugin is compatible with the current runtime
+	if plugin.MinRuntimeVersion != "" && util.CompareVersion(plugin.MinRuntimeVersion, RuntimeVersion) > 0 {
+		return nil, fmt.Errorf("check failed: this plugin is not compatible with current vfox (>= %s), please upgrade vfox version to latest", pterm.LightRed(plugin.MinRuntimeVersion))
+	}
+	return &plugin, nil
+}
+
+// downloadPlugin download plugin from downloadUrl to plugin home directory.
+func (m *Manager) downloadPlugin(downloadUrl string) (string, error) {
+	req, err := http.NewRequest("GET", downloadUrl, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := m.httpClient().Do(req)
+	if err != nil {
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			var netErr net.Error
+			if errors.As(urlErr.Err, &netErr) && netErr.Timeout() {
+				return "", errors.New("request timeout")
+			}
+		}
+		return "", err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", fmt.Errorf("plugin not found at %s", downloadUrl)
+	}
+
+	path := filepath.Join(m.PathMeta.PluginPath, filepath.Base(downloadUrl))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	fmt.Printf("Downloading %s... \n", downloadUrl)
+	_, err = io.Copy(f, resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
 func (m *Manager) Add(pluginName, url, alias string) error {
+	pluginPath := url
 	// official plugin
 	if len(url) == 0 {
-		args := strings.Split(pluginName, "/")
-		if len(args) < 2 {
-			return fmt.Errorf("invalid plugin name, format: <category>/<plugin-name>")
+		pname := pluginName
+		// For compatibility with older versions of plugin names <category>/<plugin-name>
+		if strings.Contains(pluginName, "/") {
+			pname = strings.Split(pluginName, "/")[1]
 		}
-		category := args[0]
-		name := args[1]
-		availablePlugins, err := m.Available()
+
+		pluginManifest, err := m.fetchPluginManifest(m.GetRegistryAddress(pname + ".json"))
 		if err != nil {
 			return err
 		}
-		for _, available := range availablePlugins {
-			if category == available.Name {
-				for _, p := range available.Plugins {
-					if name == p.Filename {
-						url = p.Url
-						break
-					}
-				}
-			}
-		}
+		pluginPath = pluginManifest.DownloadUrl
 	}
-
-	pterm.Printf("Loading plugin from %s...\n", url)
-	content, err := m.loadLuaFromFileOrUrl(url)
+	tempPlugin, err := m.installPluginToTemp(pluginPath)
 	if err != nil {
-		return fmt.Errorf("failed to load plugin: %w", err)
+		return err
 	}
-	pterm.Println("Checking plugin...")
-	source, err := NewLuaPlugin(url, m)
-	if err != nil {
-		return fmt.Errorf("check plugin error: %w", err)
-	}
-	defer source.Close()
-
-	// Check if the plugin is compatible with the current runtime
-	if source.MinRuntimeVersion != "" && util.CompareVersion(source.MinRuntimeVersion, RuntimeVersion) > 0 {
-		return fmt.Errorf("check failed: this plugin is not compatible with current vfox (>= %s), please upgrade vfox version to latest", source.MinRuntimeVersion)
-	}
-
-	pname := source.Name
+	defer func() {
+		_ = os.RemoveAll(tempPlugin.Path)
+		tempPlugin.Close()
+	}()
+	// set alias name
+	pname := tempPlugin.Name
 	if len(alias) > 0 {
 		pname = alias
 	}
-	destPath := filepath.Join(m.PathMeta.PluginPath, pname, "main.lua")
-	if util.FileExists(destPath) {
+	installPath := filepath.Join(m.PathMeta.PluginPath, pname)
+	if util.FileExists(installPath) {
 		return fmt.Errorf("plugin %s already exists", pname)
 	}
-	if err = os.Mkdir(filepath.Dir(destPath), 0777); err != nil {
-		return fmt.Errorf("add plugin error: %w", err)
-	}
-	if err = os.WriteFile(destPath, []byte(content), 0777); err != nil {
-		return fmt.Errorf("add plugin error: %w", err)
+	if err = os.Rename(tempPlugin.Path, installPath); err != nil {
+		return fmt.Errorf("install plugin error: %w", err)
 	}
 	pterm.Println("Plugin info:")
-	pterm.Println("Name   ", "->", pterm.LightBlue(source.Name))
-	pterm.Println("Version", "->", pterm.LightBlue(source.Version))
-	pterm.Println("Desc   ", "->", pterm.LightBlue(source.Description))
-	pterm.Println("Path   ", "->", pterm.LightBlue(destPath))
-	pterm.Printf("Add %s plugin successfully! \n", pterm.LightGreen(pname))
-	pterm.Printf("Please use `%s` to install the version you need.\n", pterm.LightBlue(fmt.Sprintf("vfox install %s@<version>", pname)))
+	pterm.Println("Name    ", "->", pterm.LightBlue(tempPlugin.Name))
+	pterm.Println("Version ", "->", pterm.LightBlue(tempPlugin.Version))
+	pterm.Println("Homepage", "->", pterm.LightBlue(tempPlugin.Homepage))
+	pterm.Println("Desc    ", "->", pterm.LightBlue(tempPlugin.Description))
+
+	// print some notes if there are
+	if len(tempPlugin.Notes) != 0 {
+		fmt.Println(pterm.LightYellow("Notes:"))
+		for _, note := range tempPlugin.Notes {
+			fmt.Println("  -", note)
+		}
+	}
+	pterm.Printf("Add %s plugin successfully! \n", pterm.LightGreen(pluginName))
+	pterm.Printf("Please use `%s` to install the version you need.\n", pterm.LightBlue(fmt.Sprintf("vfox install %s@<version>", pluginName)))
 	return nil
+}
+
+// installPluginToTemp install plugin from path that can be a local or remote file to temp dir.
+// NOTE:
+//
+//	1.only support .lua or .zip file type plugin.
+//	2.install plugin to temp dir first, then validate the plugin, if success, return *LuaPlugin
+func (m *Manager) installPluginToTemp(path string) (*LuaPlugin, error) {
+	ext := filepath.Ext(path)
+	if ext != ".lua" && ext != ".zip" {
+		return nil, fmt.Errorf("unsupported %s type plugin to install, only supoort .lua or .zip", ext)
+	}
+	localPath := path
+	// remote file, download it first to local file.
+	if strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://") {
+		logger.Debugf("Plugin from: %s \n", path)
+		pluginPath, err := m.downloadPlugin(path)
+		if err != nil {
+			return nil, fmt.Errorf("download plugin error: %w", err)
+		}
+		localPath = pluginPath
+		defer func() {
+			_ = os.Remove(localPath)
+		}()
+	}
+	success := false
+	tempInstallPath, err := os.MkdirTemp("", "vfox-")
+	if err != nil {
+		return nil, fmt.Errorf("install plugin error: %w", err)
+	}
+	defer func() {
+		if !success {
+			_ = os.RemoveAll(tempInstallPath)
+		}
+	}()
+	// make a directory to store the plugin and rename the plugin file to main.lua
+	if ext == ".lua" {
+		logger.Debugf("Moving plugin %s to %s \n", localPath, tempInstallPath)
+		if err = os.Rename(localPath, filepath.Join(tempInstallPath, "main.lua")); err != nil {
+			return nil, fmt.Errorf("install plugin error: %w", err)
+		}
+	} else {
+		logger.Debugf("Unpacking plugin %s to %s \n", localPath, tempInstallPath)
+		if err = util.NewDecompressor(localPath).Decompress(tempInstallPath); err != nil {
+			return nil, fmt.Errorf("install plugin error: %w", err)
+		}
+	}
+
+	// validate the plugin
+	fmt.Printf("Validating %s ...\n", localPath)
+
+	plugin, err := NewLuaPlugin(tempInstallPath, m)
+	if err != nil {
+		return nil, fmt.Errorf("validate plugin failed: %w", err)
+	}
+	// Check if the plugin is compatible with the current runtime
+	if plugin.MinRuntimeVersion != "" && util.CompareVersion(plugin.MinRuntimeVersion, RuntimeVersion) > 0 {
+		return nil, fmt.Errorf("check failed: this plugin is not compatible with current vfox (>= %s), please upgrade vfox version to latest", pterm.LightRed(plugin.MinRuntimeVersion))
+	}
+
+	success = true
+
+	return plugin, nil
 }
 
 func (m *Manager) httpClient() *http.Client {
@@ -333,9 +493,9 @@ func (m *Manager) loadLuaFromFileOrUrl(path string) (string, error) {
 
 }
 
-func (m *Manager) Available() ([]*Category, error) {
+func (m *Manager) Available() (RegistryIndex, error) {
 	client := m.httpClient()
-	resp, err := client.Get(pluginIndexUrl)
+	resp, err := client.Get(m.GetRegistryAddress("index.json"))
 	if err != nil {
 		return nil, fmt.Errorf("get plugin index error: %w", err)
 	}
@@ -346,12 +506,12 @@ func (m *Manager) Available() ([]*Category, error) {
 	if str, err := io.ReadAll(resp.Body); err != nil {
 		return nil, fmt.Errorf("read plugin index error: %w", err)
 	} else {
-		var categories []*Category
-		err = json.Unmarshal(str, &categories)
+		var index RegistryIndex
+		err = json.Unmarshal(str, &index)
 		if err != nil {
 			return nil, fmt.Errorf("parse plugin index error: %w", err)
 		}
-		return categories, nil
+		return index, nil
 	}
 }
 
@@ -388,6 +548,13 @@ func (m *Manager) CleanTmp() {
 			}
 		}
 	}
+}
+
+func (m *Manager) GetRegistryAddress(uri string) string {
+	if m.Config.Registry.Address != "" {
+		return m.Config.Registry.Address + "/" + uri
+	}
+	return pluginRegistryAddress + "/" + uri
 }
 
 func NewSdkManagerWithSource(sources ...RecordSource) *Manager {

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -456,48 +456,6 @@ func (m *Manager) httpClient() *http.Client {
 	return client
 }
 
-func (m *Manager) loadLuaFromFileOrUrl(path string) (string, error) {
-	if !strings.HasSuffix(path, ".lua") {
-		return "", fmt.Errorf("%s not a lua file", path)
-	}
-	if strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://") {
-		client := m.httpClient()
-		resp, err := client.Get(path)
-		if err != nil {
-			return "", err
-		}
-		defer resp.Body.Close()
-		cd := resp.Header.Get("Content-Disposition")
-		if strings.HasPrefix(cd, "attachment") {
-			return "", fmt.Errorf("not a lua file")
-		}
-		if resp.StatusCode == http.StatusNotFound {
-			return "", fmt.Errorf("file not found")
-		}
-		if str, err := io.ReadAll(resp.Body); err != nil {
-			return "", err
-		} else {
-			return string(str), nil
-		}
-	}
-
-	if !util.FileExists(path) {
-		return "", fmt.Errorf("file not found")
-	}
-	file, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
-	str, err := io.ReadAll(file)
-	if err != nil {
-		return "", err
-	}
-	return string(str), nil
-
-}
-
 func (m *Manager) Available() (RegistryIndex, error) {
 	client := m.httpClient()
 	resp, err := client.Get(m.GetRegistryAddress("index.json"))

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -332,62 +332,6 @@ func (l *LuaPlugin) CallFunction(funcName string, args ...lua.LValue) error {
 	return nil
 }
 
-// NewLegacyLuaPlugin creates a new LuaPlugin instance from old plugin format.
-// TODO This will be deprecated in future versions.
-func NewLegacyLuaPlugin(content, path string, manager *Manager) (*LuaPlugin, error) {
-	vm := luai.NewLuaVM()
-
-	if err := vm.Prepare(&luai.PrepareOptions{
-		Config: manager.Config,
-	}); err != nil {
-		return nil, err
-	}
-
-	if err := vm.Instance.DoString(content); err != nil {
-		return nil, err
-	}
-
-	// !!!! Must be set after loading the script to prevent overwriting!
-	// set OS_TYPE and ARCH_TYPE
-	vm.Instance.SetGlobal(osType, lua.LString(util.GetOSType()))
-	vm.Instance.SetGlobal(archType, lua.LString(util.GetArchType()))
-
-	pluginObj := vm.Instance.GetGlobal(luaPluginObjKey)
-	if pluginObj.Type() == lua.LTNil {
-		return nil, fmt.Errorf("plugin object not found")
-	}
-
-	PLUGIN := pluginObj.(*lua.LTable)
-
-	source := &LuaPlugin{
-		vm:        vm,
-		pluginObj: PLUGIN,
-		Path:      path,
-		SdkName:   filepath.Base(filepath.Dir(path)),
-	}
-
-	if err := source.Validate(); err != nil {
-		return nil, err
-	}
-
-	pluginInfo := &LuaPluginInfo{}
-	err := luai.Unmarshal(PLUGIN, pluginInfo)
-	if err != nil {
-		return nil, err
-	}
-
-	source.LuaPluginInfo = pluginInfo
-
-	if !isValidName(source.Name) {
-		return nil, fmt.Errorf("invalid plugin name")
-	}
-
-	if source.Name == "" {
-		return nil, fmt.Errorf("no plugin name provided")
-	}
-	return source, nil
-}
-
 // NewLuaPlugin creates a new LuaPlugin instance from the specified directory path.
 // The plugin directory must meet one of the following conditions:
 // - The directory must contain a metadata.lua file and a hooks directory that includes all must be implemented hook functions.

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -60,7 +60,7 @@ type LuaPlugin struct {
 	Path string
 	// plugin filename, this is also alias name, sdk-name
 	SdkName string
-	LuaPluginInfo
+	*LuaPluginInfo
 }
 
 func (l *LuaPlugin) Validate() error {
@@ -370,8 +370,8 @@ func NewLegacyLuaPlugin(content, path string, manager *Manager) (*LuaPlugin, err
 		return nil, err
 	}
 
-	pluginInfo := LuaPluginInfo{}
-	err := luai.Unmarshal(PLUGIN, &pluginInfo)
+	pluginInfo := &LuaPluginInfo{}
+	err := luai.Unmarshal(PLUGIN, pluginInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -470,8 +470,8 @@ func NewLuaPlugin(pluginDirPath string, manager *Manager) (*LuaPlugin, error) {
 		return nil, err
 	}
 
-	pluginInfo := LuaPluginInfo{}
-	if err = luai.Unmarshal(PLUGIN, &pluginInfo); err != nil {
+	pluginInfo := &LuaPluginInfo{}
+	if err = luai.Unmarshal(PLUGIN, pluginInfo); err != nil {
 		return nil, err
 	}
 

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -16,6 +16,30 @@
 
 package internal
 
+const (
+	pluginRegistryAddress = "https://vfox-plugins.lhan.me"
+)
+
+// RegistryIndex is the index of the registry
+type RegistryIndex []*RegistryIndexItem
+
+// RegistryIndexItem is the item in the registry index
+type RegistryIndexItem struct {
+	Name     string `json:"name"`
+	Desc     string `json:"desc"`
+	Homepage string `json:"homepage"`
+}
+
+// RegistryPluginManifest is the manifest of a remote plugin
+type RegistryPluginManifest struct {
+	Name              string `json:"name"`
+	Version           string `json:"version"`
+	License           string `json:"license"`
+	Author            string `json:"author"`
+	DownloadUrl       string `json:"downloadUrl"`
+	MinRuntimeVersion string `json:"minRuntimeVersion"`
+}
+
 type RemotePluginInfo struct {
 	Filename string `json:"name"`
 	Author   string `json:"plugin_author"`


### PR DESCRIPTION
fix #125 
fix #119

1. Only support `.lua` or `.zip` file type plugin.
2. Compatible with old plugin update way, which means old plug-ins can still be upgraded smoothly.