### PR TITLE
fix(window environment variables): wrong type of environment variable…

### DIFF
--- a/internal/env/windows_env.go
+++ b/internal/env/windows_env.go
@@ -105,7 +105,7 @@ func (w *windowsEnvManager) Flush() (err error) {
 		}
 		userNewPaths = append(userNewPaths, v)
 	}
-	if err = w.key.SetStringValue("PATH", strings.Join(userNewPaths, ";")); err != nil {
+	if err = w.setEnv("PATH", strings.Join(userNewPaths, ";")); err != nil {
 		return err
 	}
 	// sys env
@@ -134,7 +134,7 @@ func (w *windowsEnvManager) Load(envs *Envs) error {
 		if err != nil {
 			return err
 		}
-		err = w.key.SetStringValue(k, *v)
+		err = w.setEnv(k, *v)
 		if err != nil {
 			return err
 		}
@@ -147,6 +147,13 @@ func (w *windowsEnvManager) Load(envs *Envs) error {
 		}
 	}
 	return nil
+}
+
+func (w *windowsEnvManager) setEnv(key, val string) error {
+	if strings.Contains(val, "%") {
+		return w.key.SetExpandStringValue(key, val)
+	}
+	return w.key.SetStringValue(key, val)
 }
 
 func (w *windowsEnvManager) Get(key string) (string, bool) {


### PR DESCRIPTION
… set

https://learn.microsoft.com/zh-cn/windows/win32/sysinfo/registry-value-types

according to the official window documentation,
when there is a variable to be expanded such as "%name%" in the environment variable, you need to set the registry type to REG_EXPAND_SZ, otherwise the type is REG_SZ

Closes https://github.com/version-fox/vfox/issues/159