### PR TITLE
fix(set environment variables): no need to repeatedly set environment…

### DIFF
--- a/cmd/commands/env.go
+++ b/cmd/commands/env.go
@@ -19,6 +19,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/urfave/cli/v2"
 	"github.com/version-fox/vfox/internal"
 	"github.com/version-fox/vfox/internal/env"
@@ -106,9 +107,11 @@ func envCmd(ctx *cli.Context) error {
 
 		// Takes the complement of previousPaths and sdkPaths, and removes the complement from osPaths.
 		previousPaths := env.NewPaths(env.PreviousPaths)
+		removeCnt := 0
 		for _, pp := range previousPaths.Slice() {
 			if sdkPaths.Contains(pp) {
 				previousPaths.Remove(pp)
+				removeCnt++
 			}
 		}
 		osPaths := env.NewPaths(env.OsPaths)
@@ -116,6 +119,9 @@ func envCmd(ctx *cli.Context) error {
 			for _, pp := range previousPaths.Slice() {
 				osPaths.Remove(pp)
 			}
+		} else if sdkPaths.Len() == removeCnt {
+			// sdkPaths == previousPaths, No need to set environment variables
+			return nil
 		}
 		// Set the sdk paths to the new previous paths.
 		newPreviousPathStr := sdkPaths.String()

--- a/cmd/commands/env.go
+++ b/cmd/commands/env.go
@@ -107,11 +107,11 @@ func envCmd(ctx *cli.Context) error {
 
 		// Takes the complement of previousPaths and sdkPaths, and removes the complement from osPaths.
 		previousPaths := env.NewPaths(env.PreviousPaths)
-		removeCnt := 0
+		jointCnt := 0
 		for _, pp := range previousPaths.Slice() {
 			if sdkPaths.Contains(pp) {
 				previousPaths.Remove(pp)
-				removeCnt++
+				jointCnt++
 			}
 		}
 		osPaths := env.NewPaths(env.OsPaths)
@@ -119,7 +119,7 @@ func envCmd(ctx *cli.Context) error {
 			for _, pp := range previousPaths.Slice() {
 				osPaths.Remove(pp)
 			}
-		} else if sdkPaths.Len() == removeCnt {
+		} else if sdkPaths.Len() == jointCnt {
 			// sdkPaths == previousPaths, No need to set environment variables
 			return nil
 		}


### PR DESCRIPTION
… variables

When the result of calculating __VFOX_PREVIOUS_PATHS is exactly the same as the current environment variable value, there is no need to set the environment variable again.

Closes https://github.com/version-fox/vfox/issues/161