### PR TITLE
Add `PluginDirPath` for `LuaRuntime`

### DIFF
--- a/internal/interfaces.go
+++ b/internal/interfaces.go
@@ -168,7 +168,8 @@ type LuaPluginInfo struct {
 
 // LuaRuntime represents the runtime information of the Lua environment.
 type LuaRuntime struct {
-	OsType   string `luai:"osType"`
-	ArchType string `luai:"archType"`
-	Version  string `luai:"version"`
+	OsType        string `luai:"osType"`
+	ArchType      string `luai:"archType"`
+	Version       string `luai:"version"`
+	PluginDirPath string `luai:"pluginDirPath"`
 }

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -383,9 +383,10 @@ func NewLuaPlugin(pluginDirPath string, manager *Manager) (*LuaPlugin, error) {
 	vm.Instance.SetGlobal(archType, lua.LString(util.GetArchType()))
 
 	r, err := luai.Marshal(vm.Instance, LuaRuntime{
-		OsType:   string(util.GetOSType()),
-		ArchType: string(util.GetArchType()),
-		Version:  RuntimeVersion,
+		OsType:        string(util.GetOSType()),
+		ArchType:      string(util.GetArchType()),
+		Version:       RuntimeVersion,
+		PluginDirPath: pluginDirPath,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
PHP's compilation process is so complex that I wrote a shell script for it, which can be found and executed via `PluginDirPath`. 
Or is there another way to execute the shell script?