### PR TITLE
feat: support addCmd add multiple parameters for faste

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Invoke-Expression "$(vfox activate pwsh)"
 ```bash 
 $ vfox add nodejs
 ```
+or add more SDK plugins
+```bash
+$ vfox add nodejs golang
+```
 
 #### 4. Install a runtime
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -63,6 +63,10 @@ Invoke-Expression "$(vfox activate pwsh)"
 ```bash 
 $ vfox add nodejs
 ```
+或者同时增加多个SDK插件
+```bash
+$ vfox add nodejs golang
+```
 
 #### 4. 安装运行时
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -93,6 +93,7 @@ func newCmd() *cmd {
 		commands.Update,
 		commands.Remove,
 		commands.Add,
+		commands.Config,
 		commands.Activate,
 		commands.Env,
 	}

--- a/cmd/commands/add.go
+++ b/cmd/commands/add.go
@@ -17,7 +17,6 @@
 package commands
 
 import (
-	"errors"
 	"github.com/urfave/cli/v2"
 	"github.com/version-fox/vfox/internal"
 )
@@ -42,24 +41,10 @@ var Add = &cli.Command{
 
 // addCmd is the command to add a plugin of sdk
 func addCmd(ctx *cli.Context) error {
-	args := ctx.Args()
-	var errStr = ""
-	var err error
-	for _, sdkName := range args.Slice() {
-		source := ctx.String("source")
-		alias := ctx.String("alias")
-
-		manager := internal.NewSdkManager()
-		err = manager.Add(sdkName, source, alias)
-		if err != nil {
-			errStr += err.Error() + "\r\n"
-			continue
-		}
-		manager.Close()
-	}
-	if errStr != "" {
-		err = errors.New(errStr)
-	}
-
-	return err
+	manager := internal.NewSdkManager()
+	defer manager.Close()
+	sdkName := ctx.Args().First()
+	source := ctx.String("source")
+	alias := ctx.String("alias")
+	return manager.Add(sdkName, source, alias)
 }

--- a/cmd/commands/add.go
+++ b/cmd/commands/add.go
@@ -17,6 +17,7 @@
 package commands
 
 import (
+	"errors"
 	"github.com/urfave/cli/v2"
 	"github.com/version-fox/vfox/internal"
 )
@@ -41,10 +42,24 @@ var Add = &cli.Command{
 
 // addCmd is the command to add a plugin of sdk
 func addCmd(ctx *cli.Context) error {
-	manager := internal.NewSdkManager()
-	defer manager.Close()
-	sdkName := ctx.Args().First()
-	source := ctx.String("source")
-	alias := ctx.String("alias")
-	return manager.Add(sdkName, source, alias)
+	args := ctx.Args()
+	var errStr = ""
+	var err error
+	for _, sdkName := range args.Slice() {
+		source := ctx.String("source")
+		alias := ctx.String("alias")
+
+		manager := internal.NewSdkManager()
+		err = manager.Add(sdkName, source, alias)
+		if err != nil {
+			errStr += err.Error() + "\r\n"
+			continue
+		}
+		manager.Close()
+	}
+	if errStr != "" {
+		err = errors.New(errStr)
+	}
+
+	return err
 }

--- a/cmd/commands/add.go
+++ b/cmd/commands/add.go
@@ -17,13 +17,14 @@
 package commands
 
 import (
+	"errors"
 	"github.com/urfave/cli/v2"
 	"github.com/version-fox/vfox/internal"
 )
 
 var Add = &cli.Command{
 	Name:  "add",
-	Usage: "Add a plugin",
+	Usage: "Add plugins, use blank spaces separate the SDK name",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "source",
@@ -41,10 +42,31 @@ var Add = &cli.Command{
 
 // addCmd is the command to add a plugin of sdk
 func addCmd(ctx *cli.Context) error {
-	manager := internal.NewSdkManager()
-	defer manager.Close()
-	sdkName := ctx.Args().First()
-	source := ctx.String("source")
-	alias := ctx.String("alias")
-	return manager.Add(sdkName, source, alias)
+	args := ctx.Args()
+	var errStr = ""
+	var source = ""
+	var alias = ""
+	var err error
+	for index, sdkName := range args.Slice() {
+		if index == 0 {
+			source = ctx.String("source")
+			alias = ctx.String("alias")
+		} else {
+			source = ""
+			alias = ""
+		}
+
+		manager := internal.NewSdkManager()
+		err = manager.Add(sdkName, source, alias)
+		if err != nil {
+			errStr += err.Error() + "\r\n"
+			continue
+		}
+		manager.Close()
+	}
+	if errStr != "" {
+		err = errors.New(errStr)
+	}
+
+	return err
 }

--- a/cmd/commands/available.go
+++ b/cmd/commands/available.go
@@ -54,7 +54,7 @@ func availableCmd(ctx *cli.Context) error {
 		WithHasHeader().
 		WithSeparator("\t ").
 		WithData(data).Render()
-	pterm.Printf("Please use %s to install plugin\n", pterm.LightBlue("vfox add <plugin name>"))
+	pterm.Printf("Please use %s to install plugins\n", pterm.LightBlue("vfox add <plugin name>"))
 	return nil
 
 }

--- a/cmd/commands/base.go
+++ b/cmd/commands/base.go
@@ -2,3 +2,4 @@ package commands
 
 const CategorySDK = "SDK"
 const CategoryPlugin = "Plugin"
+const ConfigPlugin = "Config"

--- a/cmd/commands/config.go
+++ b/cmd/commands/config.go
@@ -1,0 +1,76 @@
+/*
+ *    Copyright 2024 Han Li and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package commands
+
+import (
+	"github.com/urfave/cli/v2"
+	"github.com/version-fox/vfox/internal"
+)
+
+var Config = &cli.Command{
+	Name:  "config",
+	Usage: "Config operation, list, storage etc.",
+	Subcommands: []*cli.Command{
+		{
+			Name:    "list",
+			Aliases: []string{"ls"},
+			Usage:   "list all config info",
+			Action:  ConfigListCmd,
+		},
+		{
+			Name:  "storage",
+			Usage: "Update storage info, such as sdkPath",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "sdk-path",
+					Usage: "storage sdk path",
+				},
+			},
+			Action: configCmd,
+		},
+	},
+	Category: ConfigPlugin,
+}
+
+// configCmd config such as storage sdkPath
+func configCmd(ctx *cli.Context) error {
+	sdkPath := ctx.String("sdk-path")
+
+	manager := internal.NewSdkManager()
+	defer manager.Close()
+
+	var err error
+	if sdkPath != "" {
+		err = manager.UpdateConfigStorageSdkPath(sdkPath)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+// ConfigListCmd config list all
+func ConfigListCmd(ctx *cli.Context) error {
+	ctx.Args().First()
+
+	manager := internal.NewSdkManager()
+	defer manager.Close()
+	manager.PrintConfigInfo()
+	return nil
+}

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -147,6 +147,10 @@ If you don't know which plugin to add, you can use the `vfox available` command 
 ```bash 
 $ vfox add nodejs
 ```
+or add more SDK plugins
+```bash
+$ vfox add nodejs golang
+```
 
 ## 4. Install a runtime
 

--- a/docs/plugins/create/howto.md
+++ b/docs/plugins/create/howto.md
@@ -212,7 +212,7 @@ Currently, VersionFox plugin testing is straightforward. You only need to place 
 
 ## Publish to the public registry
 
-`vfox` allows custom installation of plugins, such as `vfox add --source https://github.com/version-fox/vfox-nodejs/releases/download/v0.0.5/vfox-nodejs_0.0.5.zip`
+`vfox` allows custom installation of plugins, such as `vfox add --source https://github.com/version-fox/vfox-nodejs/releases/download/v0.0.5/vfox-nodejs_0.0.5.zip`, --alias and --source only support first SDK name.
 
 In order to make it easier for your users, you can add the plugin to the public registry to list your plugin and easily install it with shorter commands, such as `vfox add nodejs`.
 

--- a/docs/usage/all-commands.md
+++ b/docs/usage/all-commands.md
@@ -70,7 +70,7 @@ vfox update --all # update all installed plugins
 ```shell
 vfox - VersionFox, a tool for sdk version management
 vfox available List all available plugins
-vfox add [--alias <sdk-name> --source <url/path> ] <plugin-name>  Add a plugin from offical repository or custom source
+vfox add [--alias <sdk-name> --source <url/path> ] <plugin-name>  Add plugins from offical repository or custom source, --alias and --source only support first SDK name.
 vfox remove <sdk-name>          Remove a plugin
 vfox update [<sdk-name> | --all] Update a specified or all plugin(s)
 vfox info <sdk-name>            Show plugin info

--- a/docs/zh-hans/plugins/create/howto.md
+++ b/docs/zh-hans/plugins/create/howto.md
@@ -195,7 +195,7 @@ end
 
 ## 向官方插件存储库提交插件
 
-vfox可以允许自定义安装插件，比如`vfox add --source https://github.com/version-fox/vfox-nodejs/releases/download/v0.0.5/vfox-nodejs_0.0.5.zip `
+vfox可以允许自定义安装插件，比如`vfox add --source https://github.com/version-fox/vfox-nodejs/releases/download/v0.0.5/vfox-nodejs_0.0.5.zip `, --alias and --source 仅支持第一个插件.
 
 为了使你的用户更轻松，你可以将插件添加到官方插件存储库中，以列出你的插件并使用较短的命令轻松安装，比如 `vfox add nodejs`。
 

--- a/docs/zh-hans/usage/all-commands.md
+++ b/docs/zh-hans/usage/all-commands.md
@@ -73,7 +73,7 @@ vfox update --all # 更新所有已安装插件
 ```shell
 vfox - VersionFox, a tool for sdk version management
 vfox available      List all available plugins
-vfox add [--alias <sdk-name> --source <url/path> ] <plugin-name>  Add a plugin from offical repository or custom source
+vfox add [--alias <sdk-name> --source <url/path> ] <plugin-name>  Add plugins from offical repository or custom source, --alias and --source only support first SDK name.
 vfox remove <sdk-name>          Remove a plugin
 vfox update [<sdk-name> | --all] Update a specified or all plugin(s)
 vfox info <sdk-name>            Show plugin info

--- a/docs/zh-hans/usage/core-commands.md
+++ b/docs/zh-hans/usage/core-commands.md
@@ -34,6 +34,10 @@ vfox add [options] <plugin-name>
 ```shell
 $ vfox add --alias node nodejs
 ```
+或者安装多个仓库插件
+```bash
+$ vfox add nodejs golang
+```
 
 **安装自定义插件**
 ```shell

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"github.com/version-fox/vfox/internal/logger"
 	"github.com/version-fox/vfox/internal/util"
 	"gopkg.in/yaml.v3"
 	"os"
@@ -30,6 +31,7 @@ type Config struct {
 }
 
 const filename = "config.yaml"
+const VFoxPath = ".version-fox"
 
 var (
 	defaultConfig = &Config{
@@ -72,4 +74,30 @@ func NewConfigWithPath(p string) (*Config, error) {
 func NewConfig(path string) (*Config, error) {
 	p := filepath.Join(path, filename)
 	return NewConfigWithPath(p)
+}
+
+func GetHomePath() string {
+	userHomeDir, _ := os.UserHomeDir()
+	homePath := filepath.Join(userHomeDir, VFoxPath)
+	return homePath
+}
+
+// SaveConfig save config to config.yaml
+func SaveConfig(config *Config) bool {
+	content, err := yaml.Marshal(config)
+	if err != nil {
+		return false
+	}
+
+	err = util.FileSave(filepath.Join(GetHomePath(), filename), content)
+	logger.Info(string(content))
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+func GetConfig(config *Config) string {
+	content, _ := yaml.Marshal(config)
+	return string(content)
 }

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -569,8 +569,26 @@ func (m *Manager) GetRegistryAddress(uri string) string {
 	return pluginRegistryAddress + "/" + uri
 }
 
+// UpdateConfigStorageSdkPath update config storage sdk path
+func (m *Manager) UpdateConfigStorageSdkPath(sdkPath string) error {
+	if sdkPath != "" && m.Config.Storage.SdkPath != sdkPath {
+		m.Config.Storage.SdkPath = sdkPath
+		config.SaveConfig(m.Config)
+	}
+	return nil
+}
+
+func (m *Manager) PrintConfigInfo() {
+	getConfig := config.GetConfig(m.Config)
+	logger.Info(getConfig)
+}
+
+func GetPathMeta() (*PathMeta, error) {
+	return newPathMeta()
+}
+
 func NewSdkManager() *Manager {
-	meta, err := newPathMeta()
+	meta, err := GetPathMeta()
 	if err != nil {
 		panic("Init path meta error")
 	}

--- a/internal/path.go
+++ b/internal/path.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"fmt"
+	"github.com/version-fox/vfox/internal/config"
 	"os"
 	"path/filepath"
 
@@ -41,10 +42,10 @@ func newPathMeta() (*PathMeta, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get user home dir error: %w", err)
 	}
-	pluginPath := filepath.Join(userHomeDir, ".version-fox", "plugin")
-	homePath := filepath.Join(userHomeDir, ".version-fox")
-	sdkCachePath := filepath.Join(userHomeDir, ".version-fox", "cache")
-	tmpPath := filepath.Join(userHomeDir, ".version-fox", "temp")
+	pluginPath := filepath.Join(userHomeDir, config.VFoxPath, "plugin")
+	homePath := config.GetHomePath()
+	sdkCachePath := filepath.Join(userHomeDir, config.VFoxPath, "cache")
+	tmpPath := filepath.Join(userHomeDir, config.VFoxPath, "temp")
 	_ = os.MkdirAll(sdkCachePath, 0755)
 	_ = os.MkdirAll(pluginPath, 0755)
 	_ = os.MkdirAll(tmpPath, 0755)

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -22,6 +22,14 @@ import (
 	"path/filepath"
 )
 
+func FileSave(file string, data []byte) error {
+	err := os.WriteFile(file, data, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func FileExists(filename string) bool {
 	_, err := os.Stat(filename)
 	if os.IsNotExist(err) {


### PR DESCRIPTION
#200 resolve the issue;
add multiple parameters for vfox add sdkname
--alias and --source only support first SDK name.

for example:
`vfox add nodejs golang java python`
