### PR TITLE
fix prefix match error

### DIFF
--- a/internal/sdk.go
+++ b/internal/sdk.go
@@ -254,7 +254,7 @@ func (b *Sdk) PreUse(version Version, scope UseScope) (Version, error) {
 			installedVersions = append(installedVersions, string(sdk.Main.Version))
 		}
 		sort.Sort(installedVersions)
-		prefix := string(version) + "."
+		prefix := string(version)
 		for _, v := range installedVersions {
 			if strings.HasPrefix(v, prefix) {
 				newVersion = Version(v)

--- a/internal/sdk.go
+++ b/internal/sdk.go
@@ -256,6 +256,10 @@ func (b *Sdk) PreUse(version Version, scope UseScope) (Version, error) {
 		sort.Sort(installedVersions)
 		prefix := string(version)
 		for _, v := range installedVersions {
+			if prefix == v {
+				newVersion = Version(v)
+				break
+			}
 			if strings.HasPrefix(v, prefix) {
 				newVersion = Version(v)
 				break


### PR DESCRIPTION
```powershell
PS C:\Users\zhylmzr> vfox --version
vfox version 0.4.0
PS C:\Users\zhylmzr> vfox u golang
Please select a version of golang:
  -> 1.22.2
golang@ is not installed
```

fix #225 