### PR TITLE
fix: match version from smallest to largest

### DIFF
--- a/internal/sdk.go
+++ b/internal/sdk.go
@@ -253,7 +253,7 @@ func (b *Sdk) PreUse(version Version, scope UseScope) (Version, error) {
 		for _, sdk := range installedSdks {
 			installedVersions = append(installedVersions, string(sdk.Main.Version))
 		}
-		sort.Sort(installedVersions)
+		sort.Sort(sort.Reverse(installedVersions))
 		prefix := string(version)
 		for _, v := range installedVersions {
 			if prefix == v {

--- a/internal/util/verison.go
+++ b/internal/util/verison.go
@@ -36,8 +36,8 @@ func (s VersionSort) Less(i, j int) bool {
 }
 
 func CompareVersion(v1, v2 string) int {
-	parts1 := strings.Split(v1, ".")
-	parts2 := strings.Split(v2, ".")
+	parts1 := strings.FieldsFunc(v1, split)
+	parts2 := strings.FieldsFunc(v2, split)
 
 	len1 := len(parts1)
 	len2 := len(parts2)
@@ -72,4 +72,8 @@ func CompareVersion(v1, v2 string) int {
 
 	// If all parts are equal
 	return 0
+}
+
+func split(r rune) bool {
+	return r == '.' || r == '+' || r == '-'
 }


### PR DESCRIPTION
`VersionSort` sorting is done from largest to smallest, which will cause `go@1.2x` to be matched before `go@1.2`.

fixed: https://github.com/version-fox/vfox/issues/229