### PR TITLE
perf: cache `Available` results to reduce network io

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -71,6 +71,26 @@ registry:
 - https://rawcdn.githack.com/version-fox/vfox-plugins/plugins
   :::
 
+## Cache Settings <Badge type="tip" text=">= 0.4.1" vertical="middle" />
+
+`vfox` will cache the results of the `search` command (`available` hook) by default to reduce the number of network requests. The default
+cache time is `12h`.
+
+::: warning Special Value
+- `-1`: Never expire
+- `0`: Do not cache
+:::
+
+```yaml
+cache:
+  availableHookDuration: 12h # s second, m minute, h hour
+```
+
+
+::: tip Cache File Path
+`$HOME/.version-fox/plugins/<plugin-name>/available.cache`
+:::
+
 ## Config Command <Badge type="tip" text=">= 0.4.0" vertical="middle" />
 
 Setup, view config

--- a/docs/plugins/create/howto.md
+++ b/docs/plugins/create/howto.md
@@ -117,6 +117,13 @@ function PLUGIN:Available(ctx)
 end
 ```
 
+::: warning Cache
+
+`vfox` will cache the results of the `Available` hook to reduce the number of network requests. The default cache time is
+`12h`. For details, see [Cache Settings](../../guides/configuration.md#cache-settings).
+
+:::
+
 ### EnvKeys
 
 It is used to return the environment variables that need to be configured when using the SDK.

--- a/docs/usage/core-commands.md
+++ b/docs/usage/core-commands.md
@@ -13,6 +13,17 @@ vfox search <sdk-name> [...optionArgs]
 `sdk-name`: SDK name, such as `nodejs`, `custom-node`.
 `optionArgs`: Additional arguments for the search command. NOTE: Whether it is supported or not depends on the plugin.
 
+::: warning Cache
+
+`vfox` will cache the results of the `search` command to reduce the number of network requests. The default cache time is `12h`.
+
+You can disable it through the following command.
+```shell
+vfox config cache.availableHookDuration 0
+```
+For details, see [Cache Settings](../guides/configuration.md#cache-settings).
+:::
+
 ::: tip Quick install
 Select the target version, and press Enter to install quickly.
 :::

--- a/docs/zh-hans/guides/configuration.md
+++ b/docs/zh-hans/guides/configuration.md
@@ -69,6 +69,25 @@ registry:
 - https://rawcdn.githack.com/version-fox/vfox-plugins/plugins
   :::
 
+## 缓存 <Badge type="tip" text=">= 0.4.1" vertical="middle" />
+
+`vfox` 默认会缓存`search`命令的结果, 以减少网络请求次数。默认缓存时间为`12h`。
+
+::: warning 特殊值
+- `-1`: 永不过期
+- `0`: 不进行缓存
+:::
+```yaml
+cache:
+  availableHookDuration: 12h # s 秒, m 分钟, h 小时
+```
+
+
+::: tip 缓存文件路径
+`$HOME/.version-fox/plugins/<plugin-name>/available.cache`
+:::
+
+
 ## Config 命令 <Badge type="tip" text=">= 0.4.0" vertical="middle" />
 
 设置，查看配置

--- a/docs/zh-hans/plugins/create/howto.md
+++ b/docs/zh-hans/plugins/create/howto.md
@@ -108,6 +108,12 @@ function PLUGIN:Available(ctx)
 end
 ```
 
+::: warning 缓存
+
+`vfox`会缓存`Available`返回的结果, 默认缓存时间为`12h`。请查看[配置#缓存](../../guides/configuration.md#%E7%BC%93%E5%AD%98)。
+
+:::
+
 ### EnvKeys
 
 告诉`vfox`当前SDK需要配置的环境变量有哪些。

--- a/docs/zh-hans/usage/core-commands.md
+++ b/docs/zh-hans/usage/core-commands.md
@@ -13,6 +13,19 @@ vfox search <sdk-name> [...optionArgs]
 `sdk-name`: 运行时名称， 如`nodejs`、`custom-node`。
 `optionArgs`: 搜索命令的附加参数。注意：是否支持取决于插件。
 
+::: warning 缓存
+
+`vfox`会缓存`search`的结果, 默认缓存时间为`12h`。
+
+如果你想禁用，可以通过`vfox config`命令进行配置。
+```shell
+vfox config cache.availableHookDuration 0
+```
+
+其余操作, 请查看[配置#缓存](../guides/configuration.md#%E7%BC%93%E5%AD%98)。
+
+:::
+
 ::: tip 快捷安装
 选择目标版本， 回车即可快速安装。
 :::

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,135 @@
+/*
+ *    Copyright 2024 Han Li and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package cache
+
+import (
+	"encoding/gob"
+	"encoding/json"
+	"os"
+	"sync"
+	"time"
+)
+
+const (
+	NeverExpired time.Duration = -1
+)
+
+// Value CacheValue is a byte slice that can be unmarshaled into any type
+type Value []byte
+
+// Unmarshal the CacheValue into the given value
+func (c Value) Unmarshal(v any) error {
+	return json.Unmarshal(c, v)
+}
+
+// NewValue marshals the given value into a CacheValue
+func NewValue(v any) (Value, error) {
+	return json.Marshal(v)
+}
+
+// Item is a cache item
+type Item struct {
+	Val    []byte
+	Expire int64 // Expire time in UnixNano, -1 means never expire
+}
+
+// FileCache is a cache that saves to a file
+type FileCache struct {
+	mu    sync.RWMutex
+	items map[string]Item
+	path  string
+}
+
+// NewFileCache creates a new FileCache
+func NewFileCache(path string) (*FileCache, error) {
+	fc := &FileCache{
+		items: make(map[string]Item),
+		path:  path,
+	}
+	if err := fc.loadFromFile(path); err != nil {
+		return nil, err
+	}
+	return fc, nil
+}
+
+// Set a key value pair with a duration
+func (c *FileCache) Set(key string, value Value, duration time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if duration == NeverExpired {
+		c.items[key] = Item{
+			Val:    value,
+			Expire: int64(NeverExpired),
+		}
+	} else {
+		c.items[key] = Item{
+			Val:    value,
+			Expire: time.Now().Add(duration).UnixNano(),
+		}
+	}
+}
+
+// Get a value by key
+func (c *FileCache) Get(key string) (Value, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	item, exists := c.items[key]
+	if !exists || time.Now().UnixNano() > item.Expire {
+		if item.Expire != int64(NeverExpired) {
+			// Remove expired item
+			delete(c.items, key)
+			return nil, false
+		}
+	}
+	return item.Val, true
+}
+
+// Remove a key from the cache
+func (c *FileCache) Remove(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.items, key)
+}
+
+// Close the cache and save to file
+func (c *FileCache) Close() error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	file, err := os.Create(c.path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	encoder := gob.NewEncoder(file)
+	return encoder.Encode(c.items)
+}
+
+// loadFromFile loads the cache from a file
+func (c *FileCache) loadFromFile(filename string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	file, err := os.Open(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+	decoder := gob.NewDecoder(file)
+	return decoder.Decode(&c.items)
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -25,8 +25,11 @@ import (
 )
 
 const (
-	NeverExpired time.Duration = -1
+	NeverExpired ExpireTime = -1
 )
+
+// ExpireTime in UnixNano
+type ExpireTime int64
 
 // Value CacheValue is a byte slice that can be unmarshaled into any type
 type Value []byte
@@ -67,10 +70,10 @@ func NewFileCache(path string) (*FileCache, error) {
 }
 
 // Set a key value pair with a duration
-func (c *FileCache) Set(key string, value Value, duration time.Duration) {
+func (c *FileCache) Set(key string, value Value, expireTime ExpireTime) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if duration == NeverExpired {
+	if expireTime == NeverExpired {
 		c.items[key] = Item{
 			Val:    value,
 			Expire: int64(NeverExpired),
@@ -78,7 +81,7 @@ func (c *FileCache) Set(key string, value Value, duration time.Duration) {
 	} else {
 		c.items[key] = Item{
 			Val:    value,
-			Expire: time.Now().Add(duration).UnixNano(),
+			Expire: time.Now().Add(time.Duration(expireTime)).UnixNano(),
 		}
 	}
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,125 @@
+package cache
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+type kv struct {
+	key   string
+	value Value
+}
+
+type test1 struct {
+	V1 string
+	V2 int
+	V3 bool
+}
+
+func newKv(t *testing.T, v any) Value {
+	value, err := NewValue(v)
+	if err != nil {
+		t.Fatalf("Failed to create value: %v", err)
+	}
+	return value
+}
+
+func TestFileCache(t *testing.T) {
+	cache, err := NewFileCache("testfile.cache")
+	if err != nil {
+		t.Errorf("Failed to create cache: %v", err)
+	}
+	testdata := []kv{
+		{"test1", Value("test1")},
+		{"test2", newKv(t, true)},
+		{"test3", newKv(t, 123)},
+		{"test4", newKv(t, 'c')},
+	}
+	t.Run("TestSimpleType", func(t *testing.T) {
+
+		for _, d := range testdata {
+			cache.Set(d.key, d.value, NeverExpired)
+		}
+
+		for _, d := range testdata {
+			v, ok := cache.Get(d.key)
+			if !ok {
+				t.Errorf("Failed to get key %s", d.key)
+			}
+			if string(v) != string(d.value) {
+				t.Errorf("Expected %s, got %s", string(d.value), string(v))
+			}
+		}
+	})
+
+	t.Run("TestStructType", func(t *testing.T) {
+		td1 := test1{
+			V1: "test",
+			V2: 123,
+			V3: true,
+		}
+		cache.Set("test5", newKv(t, td1), NeverExpired)
+
+		v, ok := cache.Get("test5")
+		if !ok {
+			t.Errorf("Failed to get key test5")
+		}
+		result := test1{}
+		if err = v.Unmarshal(&result); err != nil {
+			t.Errorf("Failed to unmarshal: %v", err)
+		}
+		if result.V1 != td1.V1 || result.V2 != td1.V2 || result.V3 != td1.V3 {
+			t.Errorf("Expected %v, got %v", td1, result)
+		}
+	})
+
+	t.Run("TestExpire", func(t *testing.T) {
+		el := len(cache.items)
+		cache.Set("test6", newKv(t, "123"), time.Second)
+		time.Sleep(time.Second * 2)
+
+		_, ok := cache.Get("test6")
+		if ok {
+			t.Errorf("Expected key test6 to be expired")
+		}
+		if len(cache.items) != el {
+			t.Errorf("Expected %d items, got %d", el, len(cache.items))
+		}
+	})
+
+	t.Run("TestRemove", func(t *testing.T) {
+		cache.Set("test7", newKv(t, "123"), NeverExpired)
+		cache.Remove("test7")
+		_, ok := cache.Get("test7")
+		if ok {
+			t.Errorf("Expected key test7 to be removed")
+		}
+	})
+
+	t.Run("TestToFile", func(t *testing.T) {
+		for _, d := range testdata {
+			cache.Set(d.key, d.value, NeverExpired)
+		}
+
+		if err := cache.Close(); err != nil {
+			t.Errorf("Failed to close cache: %v", err)
+		}
+
+		newCache, err := NewFileCache("testfile.cache")
+		if err != nil {
+			t.Errorf("Failed to create cache: %v", err)
+		}
+		for _, d := range testdata {
+			v, ok := newCache.Get(d.key)
+			if !ok {
+				t.Errorf("Failed to get key %s", d.key)
+			}
+			if string(v) != string(d.value) {
+				t.Errorf("Expected %s, got %s", string(d.value), string(v))
+			}
+		}
+	})
+
+	defer os.Remove("testfile.cache")
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -35,6 +35,7 @@ func TestFileCache(t *testing.T) {
 		{"test2", newKv(t, true)},
 		{"test3", newKv(t, 123)},
 		{"test4", newKv(t, 'c')},
+		{"test5", nil},
 	}
 	t.Run("TestSimpleType", func(t *testing.T) {
 

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,3 +1,19 @@
+/*
+ *    Copyright 2024 Han Li and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package cache
 
 import (
@@ -77,7 +93,7 @@ func TestFileCache(t *testing.T) {
 
 	t.Run("TestExpire", func(t *testing.T) {
 		el := len(cache.items)
-		cache.Set("test6", newKv(t, "123"), time.Second)
+		cache.Set("test6", newKv(t, "123"), ExpireTime(time.Second))
 		time.Sleep(time.Second * 2)
 
 		_, ok := cache.Get("test6")

--- a/internal/config/cache.go
+++ b/internal/config/cache.go
@@ -22,7 +22,7 @@ import "time"
 // -1: never expire
 // 0: never cache
 type Cache struct {
-	AvailableHookDuration time.Duration `yaml:"availableHook"` // Available hook result cache time
+	AvailableHookDuration time.Duration `yaml:"availableHookDuration"` // Available hook result cache time
 }
 
 var (

--- a/internal/config/cache.go
+++ b/internal/config/cache.go
@@ -1,0 +1,32 @@
+/*
+ *    Copyright 2024 Han Li and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package config
+
+import "time"
+
+// Cache is the cache configuration
+// -1: never expire
+// 0: never cache
+type Cache struct {
+	AvailableHookDuration time.Duration `yaml:"availableHook"` // Available hook result cache time
+}
+
+var (
+	EmptyCache = &Cache{
+		AvailableHookDuration: 12 * time.Hour,
+	}
+)

--- a/internal/config/cache_test.go
+++ b/internal/config/cache_test.go
@@ -1,0 +1,74 @@
+/*
+ *    Copyright 2024 Han Li and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package config
+
+import (
+	"gopkg.in/yaml.v3"
+	"testing"
+	"time"
+)
+
+func TestCacheDuration_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		name    string
+		cd      CacheDuration
+		want    interface{}
+		wantErr bool
+	}{
+		{"Negative", CacheDuration(-1), -1, false},
+		{"Zero", CacheDuration(0), 0, false},
+		{"Positive", CacheDuration(time.Hour), "1h0m0s", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.cd.MarshalYAML()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("MarshalYAML() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCacheDuration_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name    string
+		node    *yaml.Node
+		want    CacheDuration
+		wantErr bool
+	}{
+		{"Negative", &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: "-1"}, CacheDuration(-1), false},
+		{"Zero", &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: "0"}, CacheDuration(0), false},
+		{"Positive", &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "1h0m0s"}, CacheDuration(time.Hour), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cd := CacheDuration(0)
+			if err := cd.UnmarshalYAML(tt.node); (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if cd != tt.want {
+				t.Errorf("UnmarshalYAML() got = %v, want %v", cd, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	Storage           *Storage           `yaml:"storage"`
 	Registry          *Registry          `yaml:"registry"`
 	LegacyVersionFile *LegacyVersionFile `yaml:"legacyVersionFile"`
+	Cache             *Cache             `yaml:"cache"`
 }
 
 const filename = "config.yaml"
@@ -38,6 +39,7 @@ var (
 		Storage:           EmptyStorage,
 		Registry:          EmptyRegistry,
 		LegacyVersionFile: EmptyLegacyVersionFile,
+		Cache:             EmptyCache,
 	}
 )
 
@@ -70,6 +72,9 @@ func NewConfigWithPath(p string) (*Config, error) {
 	}
 	if config.LegacyVersionFile == nil {
 		config.LegacyVersionFile = EmptyLegacyVersionFile
+	}
+	if config.Cache == nil {
+		config.Cache = EmptyCache
 	}
 	return config, nil
 

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -12,4 +12,4 @@ legacyVersionFile:
   enable: true
 
 cache:
-  availableHookDuration: 1s
+  availableHookDuration: -1

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -10,3 +10,6 @@ registry:
 
 legacyVersionFile:
   enable: true
+
+cache:
+  availableHookDuration: 1s

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/version-fox/vfox/internal/config"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -38,6 +39,9 @@ func TestNewConfig(t *testing.T) {
 	}
 	if !c.LegacyVersionFile.Enable {
 		t.Fatal("legacy version file enable is invalid")
+	}
+	if c.Cache.AvailableHookDuration != time.Second {
+		t.Fatal("cache available hook duration is invalid")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/version-fox/vfox/internal/config"
 	"os"
 	"testing"
-	"time"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -40,7 +39,7 @@ func TestNewConfig(t *testing.T) {
 	if !c.LegacyVersionFile.Enable {
 		t.Fatal("legacy version file enable is invalid")
 	}
-	if c.Cache.AvailableHookDuration != time.Second {
+	if c.Cache.AvailableHookDuration != config.CacheDuration(-1) {
 		t.Fatal("cache available hook duration is invalid")
 	}
 }

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -586,13 +586,13 @@ func NewLuaPlugin(pluginDirPath string, manager *Manager) (*LuaPlugin, error) {
 				}
 				table := source.vm.ReturnedValue()
 				if table == nil || table.Type() == lua.LTNil {
-					fileCache.Set(cacheKey, nil, config.Cache.AvailableHookDuration)
+					fileCache.Set(cacheKey, nil, cache.ExpireTime(config.Cache.AvailableHookDuration))
 					_ = fileCache.Close()
 				} else {
 					hookResult := AvailableHookResult{}
 					if err = luai.Unmarshal(table, &hookResult); err == nil {
 						if value, err := cache.NewValue(hookResult); err == nil {
-							fileCache.Set(cacheKey, value, config.Cache.AvailableHookDuration)
+							fileCache.Set(cacheKey, value, cache.ExpireTime(config.Cache.AvailableHookDuration))
 							_ = fileCache.Close()
 						}
 					}

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -30,8 +30,6 @@ import (
 	"github.com/version-fox/vfox/internal/luai"
 	"github.com/version-fox/vfox/internal/util"
 	lua "github.com/yuin/gopher-lua"
-	"path/filepath"
-	"regexp"
 	"strings"
 )
 

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"github.com/version-fox/vfox/internal/config"
 	"github.com/version-fox/vfox/internal/util"
 	"reflect"
 	"strings"
@@ -138,7 +139,7 @@ func testHookFunc(t *testing.T, factory func() (*Manager, *LuaPlugin, error)) {
 
 	t.Run("Available", func(t *testing.T) {
 		m, plugin, err := factory()
-		m.Config.Cache.AvailableHookDuration = time.Second * 10
+		m.Config.Cache.AvailableHookDuration = config.CacheDuration(time.Second * 10)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	_ "embed"
 
@@ -66,9 +67,10 @@ func TestNewLuaPluginWithMain(t *testing.T) {
 		}
 	})
 
-	testHookFunc(t, func() (*LuaPlugin, error) {
+	testHookFunc(t, func() (*Manager, *LuaPlugin, error) {
 		manager := NewSdkManager()
-		return NewLuaPlugin(pluginPathWithMain, manager)
+		plugin, err := NewLuaPlugin(pluginPathWithMain, manager)
+		return manager, plugin, err
 	})
 
 }
@@ -124,33 +126,50 @@ func TestNewLuaPluginWithMetadataAndHooks(t *testing.T) {
 			}
 		}
 	})
-	testHookFunc(t, func() (*LuaPlugin, error) {
+	testHookFunc(t, func() (*Manager, *LuaPlugin, error) {
 		manager := NewSdkManager()
-		return NewLuaPlugin(pluginPathWithMetadata, manager)
+		plugin, err := NewLuaPlugin(pluginPathWithMetadata, manager)
+		return manager, plugin, err
 	})
 }
 
-func testHookFunc(t *testing.T, factory func() (*LuaPlugin, error)) {
+func testHookFunc(t *testing.T, factory func() (*Manager, *LuaPlugin, error)) {
 	t.Helper()
 
 	t.Run("Available", func(t *testing.T) {
-		plugin, err := factory()
+		m, plugin, err := factory()
+		m.Config.Cache.AvailableHookDuration = time.Second * 10
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		pkgs, err := plugin.Available([]string{})
-		if err != nil {
-			t.Fatal(err)
+		getResult := func() string {
+			pkgs, err := plugin.Available([]string{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			v := pkgs[0].Main.Note
+			return v
+		}
+		version := getResult()
+		for i := 0; i < 6; i++ {
+			v := getResult()
+			if version != v {
+				t.Errorf("expected version '%s', got '%s'", version, v)
+			}
+			time.Sleep(time.Second)
 		}
 
-		if len(pkgs) != 1 {
-			t.Errorf("expected 1 package, got %d", len(pkgs))
+		time.Sleep(time.Second * 10)
+
+		vv := getResult()
+		if version == vv {
+			t.Errorf("expected version to be different, got '%s'", vv)
 		}
 	})
 
 	t.Run("PreInstall", func(t *testing.T) {
-		plugin, err := factory()
+		_, plugin, err := factory()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -199,7 +218,7 @@ func testHookFunc(t *testing.T, factory func() (*LuaPlugin, error)) {
 	})
 
 	t.Run("EnvKeys", func(t *testing.T) {
-		plugin, err := factory()
+		_, plugin, err := factory()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -253,7 +272,7 @@ func testHookFunc(t *testing.T, factory func() (*LuaPlugin, error)) {
 	})
 
 	t.Run("PreUse", func(t *testing.T) {
-		plugin, err := factory()
+		_, plugin, err := factory()
 
 		inputVersion := Version("20.0")
 		previousVersion := Version("21.0")
@@ -295,7 +314,7 @@ func testHookFunc(t *testing.T, factory func() (*LuaPlugin, error)) {
 	})
 
 	t.Run("ParseLegacyFile", func(t *testing.T) {
-		plugin, err := factory()
+		_, plugin, err := factory()
 		version, err := plugin.ParseLegacyFile("/path/to/legacy/.node-version", func() []Version {
 			return nil
 		})
@@ -327,7 +346,7 @@ func testHookFunc(t *testing.T, factory func() (*LuaPlugin, error)) {
 	})
 
 	t.Run("PreUninstall", func(t *testing.T) {
-		plugin, err := factory()
+		_, plugin, err := factory()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/testdata/plugins/java_with_main/main.lua
+++ b/internal/testdata/plugins/java_with_main/main.lua
@@ -93,7 +93,7 @@ function PLUGIN:Available(ctx)
     return {
         {
             version = "xxxx",
-            note = "LTS",
+            note = os.time(),
             addition = {
                 {
                     name = "npm",

--- a/internal/testdata/plugins/java_with_metadata/hooks/available.lua
+++ b/internal/testdata/plugins/java_with_metadata/hooks/available.lua
@@ -2,6 +2,7 @@
 --- @param ctx table Empty table used as context, for future extension
 --- @return table Descriptions of available versions and accompanying tool descriptions
 function PLUGIN:Available(ctx)
+    print("invoke Available Hook")
     return {
         {
             version = "xxxx",

--- a/internal/testdata/plugins/java_with_metadata/hooks/available.lua
+++ b/internal/testdata/plugins/java_with_metadata/hooks/available.lua
@@ -6,7 +6,7 @@ function PLUGIN:Available(ctx)
     return {
         {
             version = "xxxx",
-            note = "LTS",
+            note = os.time(),
             addition = {
                 {
                     name = "npm",


### PR DESCRIPTION
- Wrap the Available hook in the plugin with a layer of cache so that the cache can be used regardless of `vfox` calls or calls within the plugin.
- Allows configurable cache duration, defaults to 12 hours.

see https://github.com/version-fox/vfox/issues/227#issuecomment-2074205042