### PR TITLE
fix(clink prompt sdk name): matches any programming language

### DIFF
--- a/internal/shell/clink_vfox.lua
+++ b/internal/shell/clink_vfox.lua
@@ -7,8 +7,9 @@ clink.argmatcher('vfox'):nofiles():setdelayinit(function(vfox)
 
     local vfox_available = io.popen('vfox available')
     for line in vfox_available:lines() do
-        local sdk, yes = line:gsub('%c%[%d+m', ''):match('^(%a+)%s+(%u%u%u?)')
-        if sdk and yes and (yes == 'YES' or yes == 'NO') then
+        local sdk, yes = line:gsub('%c%[%d+m', ''):match('^(.+)%s(%u%u%u?)%s')
+        if (yes == 'YES' or yes == 'NO') and sdk then
+            sdk = sdk:gsub('%s*$', '')
             table.insert(vfox_sdk_table, sdk)
         end
     end


### PR DESCRIPTION
link: https://en.wikipedia.org/wiki/List_of_programming_languages

If languages ​​like `Objective-C` , `C++` are added in the future, this bug will need to be fixed.