### PR TITLE
fix: return err if symlink is not created

### DIFF
--- a/internal/sdk.go
+++ b/internal/sdk.go
@@ -19,7 +19,6 @@ package internal
 import (
 	"errors"
 	"fmt"
-	"github.com/version-fox/vfox/internal/shim"
 	"io"
 	"net"
 	"net/http"
@@ -30,6 +29,8 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+
+	"github.com/version-fox/vfox/internal/shim"
 
 	"github.com/pterm/pterm"
 	"github.com/schollz/progressbar/v3"
@@ -67,14 +68,14 @@ func (s *SdkEnv) linkToCurrent(targetDir string) (*env.Paths, error) {
 		}
 		if util.FileExists(tp) {
 			if err := os.Remove(tp); err != nil {
-				logger.Debugf("Failed to remove symlink %s\n", tp)
-				continue
+				logger.Errorf("Failed to remove symlink %s\n", tp)
+				return nil, err
 			}
 		}
 		_ = os.MkdirAll(targetDir, 0755)
 		if err := util.MkSymlink(p, tp); err != nil {
-			logger.Debugf("Failed to create symlink %s -> %s\n", p, targetDir)
-			continue
+			logger.Errorf("Failed to create symlink %s -> %s\n", p, tp)
+			return nil, err
 		}
 		paths.Add(tp)
 	}


### PR DESCRIPTION
I would have tried to create a plugin yesterday (https://github.com/anweber/vfox-mani). It was hard because vfox is not always chatty about error. For example, the symlink was not created, but the command `vfox use mani@0.25.0` was completed without error.
Apparently, the optional hook `pre_use.lua` is expected to return the current version. Only then will the current folder be created, for which a symlink is generated. The dependencies are not well documented, so I was only able to determine the cause of the error after debugging vfox.
This MR now always logs the error and also displays the file name used (`targetDir .. "/current"`). This MR, does not fix the problem, that the first `PATH` variable must always have a subfolder `current`. If there is no pre_use hook, this folder may not exist.