### PR TITLE
fix: do not clean the temporary directory of the current terminal

### DIFF
--- a/internal/manager.go
+++ b/internal/manager.go
@@ -594,7 +594,6 @@ func (m *Manager) CleanTmp() {
 	}
 	dir, err := os.ReadDir(m.PathMeta.TempPath)
 	if err == nil {
-		_ = os.RemoveAll(m.PathMeta.CurTmpPath)
 		for _, file := range dir {
 			if !file.IsDir() {
 				continue


### PR DESCRIPTION
fix: https://github.com/version-fox/vfox/issues/280

Keep temporary directory soft links when starting the terminal