### PR TITLE
docs: fix incorrect URL reference in JSON library documentation

### DIFF
--- a/docs/plugins/library/json.md
+++ b/docs/plugins/library/json.md
@@ -1,7 +1,6 @@
 # JSON Library
 
-Based on [gopher-json](https://github.com/layeh/gopher-json/)
-
+Based on [gopher-json](https://github.com/layeh/gopher-json)
 
 **Usage**
 ```lua

--- a/docs/zh-hans/plugins/library/json.md
+++ b/docs/zh-hans/plugins/library/json.md
@@ -1,6 +1,6 @@
 # Json标准库
 
-`vfox`提供的`json`库是基于[gopher-json](https://github.com/layeh/gopher-json)实现的。
+`vfox` 提供的 `json` 库是基于 [gopher-json](https://github.com/layeh/gopher-json) 实现的。
 
 
 **使用**

--- a/docs/zh-hans/plugins/library/json.md
+++ b/docs/zh-hans/plugins/library/json.md
@@ -1,6 +1,6 @@
 # Json标准库
 
-`vfox`提供的`json`库是基于[gopher-json](https://github.com/PuerkitoBio/goquery)实现的。
+`vfox`提供的`json`库是基于[gopher-json](https://github.com/layeh/gopher-json)实现的。
 
 
 **使用**


### PR DESCRIPTION
Related to #303
close: #303

Corrects the URL reference in the documentation for the JSON library.

- Updates the URL reference in `docs/plugins/library/json.md` to the correct `gopher-json` link, removing an unnecessary trailing slash.
- Fixes the incorrect URL in `docs/zh-hans/plugins/library/json.md`, ensuring it points to `gopher-json` instead of `goquery`, aligning with the correct source.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/version-fox/vfox/issues/303?shareId=107307de-aedc-4ac6-806f-d1ae438a52f9).