### PR TITLE
fix: determine whether vfox has been initialized in the parent process

### DIFF
--- a/internal/shell/zsh.go
+++ b/internal/shell/zsh.go
@@ -25,25 +25,27 @@ type zsh struct{}
 var Zsh = zsh{}
 
 const zshHook = `
-{{.EnvContent}}
+if [[ -z "$__VFOX_PID" ]]; then
+  {{.EnvContent}}
 
-export __VFOX_PID=$$;
+  export __VFOX_PID=$$;
 
-_vfox_hook() {
-  trap -- '' SIGINT;
-  eval "$("{{.SelfPath}}" env -s zsh)";
-  trap - SIGINT;
-}
-typeset -ag precmd_functions;
-if [[ -z "${precmd_functions[(r)_vfox_hook]+1}" ]]; then
-  precmd_functions=( _vfox_hook ${precmd_functions[@]} )
+  _vfox_hook() {
+    trap -- '' SIGINT;
+    eval "$("{{.SelfPath}}" env -s zsh)";
+    trap - SIGINT;
+  }
+  typeset -ag precmd_functions;
+  if [[ -z "${precmd_functions[(r)_vfox_hook]+1}" ]]; then
+    precmd_functions=( _vfox_hook ${precmd_functions[@]} )
+  fi
+  typeset -ag chpwd_functions;
+  if [[ -z "${chpwd_functions[(r)_vfox_hook]+1}" ]]; then
+    chpwd_functions=( _vfox_hook ${chpwd_functions[@]} )
+  fi
+
+  trap 'vfox env --cleanup' EXIT
 fi
-typeset -ag chpwd_functions;
-if [[ -z "${chpwd_functions[(r)_vfox_hook]+1}" ]]; then
-  chpwd_functions=( _vfox_hook ${chpwd_functions[@]} )
-fi
-
-trap 'vfox env --cleanup' EXIT
 `
 
 func (z zsh) Activate() (string, error) {


### PR DESCRIPTION
尝试修复问题 #294

增加判断，如果父进程已经存在变量`__VFOX_PID`则不在执行初始化, 避免子进程创建冗余目录干扰共享的环境变量
