### PR TITLE
fix: lua encode structural error

### DIFF
--- a/internal/module/json/json.go
+++ b/internal/module/json/json.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // Preload adds json to the given Lua state's package.preload table. After it
@@ -117,7 +117,7 @@ func (j jsonValue) MarshalJSON() (data []byte, err error) {
 
 		switch key.Type() {
 		case lua.LTNil: // empty table
-			data = []byte(`[]`)
+			data = []byte(`null`)
 		case lua.LTNumber:
 			arr := make([]jsonValue, 0, converted.Len())
 			expectedKey := lua.LNumber(1)


### PR DESCRIPTION
# Ⅰ. Describe what this PR does

Pass an object to lua for modification, and the resulting return value. After serialization the field type changed. 


if not fix, the jsonBytes whill be 

```
 {"metadata":[],"spec":{"containers":[{"image":"centos:7","name":"centos","resources":[]}]},"status":[]}
```

- metadata
- status
- resources