### PR TITLE
fix(clink_vfox.lua): Lua coroutine executes

### DIFF
--- a/internal/manager.go
+++ b/internal/manager.go
@@ -706,7 +706,7 @@ func (m *Manager) ParseLegacyFile(output func(sdkname, version string)) error {
 func NewSdkManager() *Manager {
 	meta, err := newPathMeta()
 	if err != nil {
-		panic("Init path meta error")
+		panic("Init path meta error " + err.Error())
 	}
 	return newSdkManager(meta)
 }

--- a/internal/shell/clink_vfox.lua
+++ b/internal/shell/clink_vfox.lua
@@ -6,7 +6,7 @@ clink.argmatcher('vfox'):nofiles():setdelayinit(function(vfox)
     end
 
     local current_timestamp = os.time()
-    local file_name = os.getenv('USERPROFILE') .. '\\available.txt'
+    local file_name = os.getenv('USERPROFILE') .. '\\vfox_available.txt'
     local file_available = io.open(file_name, 'r')
     if file_available then
         local file_timestamp = tonumber(file_available:read('*l'))
@@ -135,13 +135,17 @@ local vfox_setenv = function(str)
 end
 
 local vfox_task = coroutine.create(function()
+    os.setenv('__VFOX_PID', os.getpid())
     local vfox_activate = io.popen('vfox activate clink')
     for line in vfox_activate:lines() do
         vfox_setenv(line)
     end
     vfox_activate:close()
-    os.setenv('__VFOX_PID', os.getpid())
-    os.execute('vfox env -c')
+
+    local cleanup = coroutine.create(function()
+        os.execute('vfox env -c')
+    end)
+    coroutine.resume(cleanup)
 end)
 coroutine.resume(vfox_task)
 


### PR DESCRIPTION
1. Modify the cache file to vfox_available.txt, the meaning is clearer
2. When multiple commands are executed simultaneously in a Lua coroutine, only the first command succeeds, and the subsequent commands block the coroutine, so the second command is run through the coroutine
3. Print the error information returned by newPathMeta to facilitate troubleshooting