### PR TITLE
docs: add tips for `clink&cmder` integration

### DIFF
--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -126,6 +126,9 @@ y
    clink info | findstr scripts
    ```
 2. Copy [clink_vfox.lua](https://github.com/version-fox/vfox/blob/main/internal/shell/clink_vfox.lua) to the scripts directory
+   ::: tip
+   The `clink_vfox.lua` script only needs to be placed in one of the directories, not in each directory.
+   :::
 3. Restart Clink or Cmder
 :::
 

--- a/docs/zh-hans/guides/quick-start.md
+++ b/docs/zh-hans/guides/quick-start.md
@@ -129,6 +129,9 @@ y
    clink info | findstr scripts
    ```
 2. 复制 [clink_vfox.lua](https://github.com/version-fox/vfox/blob/main/internal/shell/clink_vfox.lua) 到脚本目录下
+   ::: tip 注意
+   `clink_vfox.lua`脚本只需放置在其中一个目录中，无需放入每个目录。
+   :::
 3. 重启 Clink 或 Cmder
 
 :::


### PR DESCRIPTION
* docs: add tips for `clink&cmder` integration
* [BUG]: Error 「 panic: panic: Init path meta error create temp dir failed: mkdir C:\Users\xxxxx\.version-fox\temp\1743004800-5460: Cannot create a file when that file already exists.」 in cmder terminal after win11 startup #439