### PR TITLE
fix: forward parameters with splatting on powershell shims

### DIFF
--- a/internal/shim/shim_windows.go
+++ b/internal/shim/shim_windows.go
@@ -42,7 +42,7 @@ param (
     $params
 )
 
-& '%s' $params
+& '%s' @params
 `
 
 //go:embed binary/shim.exe


### PR DESCRIPTION
fix #444 by utilizing `@params` (Splatting) instead of `$params`. 
This change should ensure that arguments are passed to the underlying executables correctly.

Users might need to regenerate their shims by runing `vfox use -g` to reflect new change.