### PR TITLE
fix: .`tool-versions` not working Nushell

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/version-fox/vfox
 
-go 1.21.7
-toolchain go1.24.1
+go 1.23.0
+
+toolchain go1.24.2
 
 require (
 	atomicgo.dev/cursor v0.2.0


### PR DESCRIPTION
The issue here was that the global environment was being inserted at the beginning of the MultiToolVersions slice, which mistakenly gave it a higher precedence than everything else in the slice. It should have a lowever precedence than the working directory, so the code has been modified to place it after that in the slice.

Fixes #420