### PR TITLE
refactor: replace luai tags with json for consistency

### DIFF
--- a/cmd/commands/current.go
+++ b/cmd/commands/current.go
@@ -44,7 +44,7 @@ func currentCmd(ctx *cli.Context) error {
 		}
 
 		for _, s := range allSdk {
-			name := s.Plugin.SdkName
+			name := s.Name
 			current := s.Current()
 			if current == "" {
 				pterm.Printf("%s -> N/A \n", name)

--- a/cmd/commands/list.go
+++ b/cmd/commands/list.go
@@ -48,7 +48,7 @@ func listCmd(ctx *cli.Context) error {
 		tree := pterm.LeveledList{}
 
 		for _, s := range allSdk {
-			name := s.Plugin.SdkName
+			name := s.Name
 			tree = append(tree, pterm.LeveledListItem{Level: 0, Text: name})
 			for _, version := range s.List() {
 				tree = append(tree, pterm.LeveledListItem{Level: 1, Text: "v" + string(version)})

--- a/cmd/commands/update.go
+++ b/cmd/commands/update.go
@@ -50,7 +50,7 @@ func updateCmd(ctx *cli.Context) error {
 				total = len(sdks)
 			)
 			for _, s := range sdks {
-				sdkName := s.Plugin.SdkName
+				sdkName := s.Name
 				index++
 				pterm.Printf("[%s/%d]: Updating %s plugin...\n", pterm.Green(index), total, pterm.Green(sdkName))
 				if err = manager.Update(sdkName); err != nil {

--- a/internal/interfaces.go
+++ b/internal/interfaces.go
@@ -23,10 +23,10 @@ import (
 )
 
 type LuaCheckSum struct {
-	Sha256 string `luai:"sha256"`
-	Sha512 string `luai:"sha512"`
-	Sha1   string `luai:"sha1"`
-	Md5    string `luai:"md5"`
+	Sha256 string `json:"sha256"`
+	Sha512 string `json:"sha512"`
+	Sha1   string `json:"sha1"`
+	Md5    string `json:"md5"`
 }
 
 func (c *LuaCheckSum) Checksum() *Checksum {
@@ -52,31 +52,31 @@ func (c *LuaCheckSum) Checksum() *Checksum {
 }
 
 type AvailableHookCtx struct {
-	Args []string `luai:"args"`
+	Args []string `json:"args"`
 }
 
 type AvailableHookResultItem struct {
-	Version string `luai:"version"`
-	Note    string `luai:"note"`
+	Version string `json:"version"`
+	Note    string `json:"note"`
 
-	Addition []*Info `luai:"addition"`
+	Addition []*Info `json:"addition"`
 }
 
 type AvailableHookResult = []*AvailableHookResultItem
 
 type PreInstallHookCtx struct {
-	Version string `luai:"version"`
+	Version string `json:"version"`
 }
 
 type PreInstallHookResultAdditionItem struct {
-	Name    string            `luai:"name"`
-	Url     string            `luai:"url"`
-	Headers map[string]string `luai:"headers"`
-	Note    string            `luai:"note"`
-	Sha256  string            `luai:"sha256"`
-	Sha512  string            `luai:"sha512"`
-	Sha1    string            `luai:"sha1"`
-	Md5     string            `luai:"md5"`
+	Name    string            `json:"name"`
+	Url     string            `json:"url"`
+	Headers map[string]string `json:"headers"`
+	Note    string            `json:"note"`
+	Sha256  string            `json:"sha256"`
+	Sha512  string            `json:"sha512"`
+	Sha1    string            `json:"sha1"`
+	Md5     string            `json:"md5"`
 }
 
 func (i *PreInstallHookResultAdditionItem) Info() *Info {
@@ -98,15 +98,15 @@ func (i *PreInstallHookResultAdditionItem) Info() *Info {
 }
 
 type PreInstallHookResult struct {
-	Version  string                              `luai:"version"`
-	Url      string                              `luai:"url"`
-	Headers  map[string]string                   `luai:"headers"`
-	Note     string                              `luai:"note"`
-	Sha256   string                              `luai:"sha256"`
-	Sha512   string                              `luai:"sha512"`
-	Sha1     string                              `luai:"sha1"`
-	Md5      string                              `luai:"md5"`
-	Addition []*PreInstallHookResultAdditionItem `luai:"addition"`
+	Version  string                              `json:"version"`
+	Url      string                              `json:"url"`
+	Headers  map[string]string                   `json:"headers"`
+	Note     string                              `json:"note"`
+	Sha256   string                              `json:"sha256"`
+	Sha512   string                              `json:"sha512"`
+	Sha1     string                              `json:"sha1"`
+	Md5      string                              `json:"md5"`
+	Addition []*PreInstallHookResultAdditionItem `json:"addition"`
 }
 
 var ErrNoVersionProvided = errors.New("no version number provided")
@@ -134,66 +134,66 @@ func (i *PreInstallHookResult) Info() (*Info, error) {
 }
 
 type PreUseHookCtx struct {
-	Cwd             string           `luai:"cwd"`
-	Scope           string           `luai:"scope"`
-	Version         string           `luai:"version"`
-	PreviousVersion string           `luai:"previousVersion"`
-	InstalledSdks   map[string]*Info `luai:"installedSdks"`
+	Cwd             string           `json:"cwd"`
+	Scope           string           `json:"scope"`
+	Version         string           `json:"version"`
+	PreviousVersion string           `json:"previousVersion"`
+	InstalledSdks   map[string]*Info `json:"installedSdks"`
 }
 
 type PreUseHookResult struct {
-	Version string `luai:"version"`
+	Version string `json:"version"`
 }
 
 type PostInstallHookCtx struct {
-	RootPath string           `luai:"rootPath"`
-	SdkInfo  map[string]*Info `luai:"sdkInfo"`
+	RootPath string           `json:"rootPath"`
+	SdkInfo  map[string]*Info `json:"sdkInfo"`
 }
 
 type EnvKeysHookCtx struct {
-	Main *Info `luai:"main"`
+	Main *Info `json:"main"`
 	// TODO Will be deprecated in future versions
-	Path    string           `luai:"path"`
-	SdkInfo map[string]*Info `luai:"sdkInfo"`
+	Path    string           `json:"path"`
+	SdkInfo map[string]*Info `json:"sdkInfo"`
 }
 
 type EnvKeysHookResultItem struct {
-	Key   string `luai:"key"`
-	Value string `luai:"value"`
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 type ParseLegacyFileHookCtx struct {
-	Filepath             string         `luai:"filepath"`
-	Filename             string         `luai:"filename"`
-	GetInstalledVersions lua.LGFunction `luai:"getInstalledVersions"`
+	Filepath             string         `json:"filepath"`
+	Filename             string         `json:"filename"`
+	GetInstalledVersions lua.LGFunction `json:"getInstalledVersions"`
 }
 
 type ParseLegacyFileResult struct {
-	Version string `luai:"version"`
+	Version string `json:"version"`
 }
 
 type PreUninstallHookCtx struct {
-	Main    *Info            `luai:"main"`
-	SdkInfo map[string]*Info `luai:"sdkInfo"`
+	Main    *Info            `json:"main"`
+	SdkInfo map[string]*Info `json:"sdkInfo"`
 }
 
 type LuaPluginInfo struct {
-	Name              string   `luai:"name"`
-	Version           string   `luai:"version"`
-	Description       string   `luai:"description"`
-	UpdateUrl         string   `luai:"updateUrl"`
-	ManifestUrl       string   `luai:"manifestUrl"`
-	Homepage          string   `luai:"homepage"`
-	License           string   `luai:"license"`
-	MinRuntimeVersion string   `luai:"minRuntimeVersion"`
-	Notes             []string `luai:"notes"`
-	LegacyFilenames   []string `luai:"legacyFilenames"`
+	Name              string   `json:"name"`
+	Version           string   `json:"version"`
+	Description       string   `json:"description"`
+	UpdateUrl         string   `json:"updateUrl"`
+	ManifestUrl       string   `json:"manifestUrl"`
+	Homepage          string   `json:"homepage"`
+	License           string   `json:"license"`
+	MinRuntimeVersion string   `json:"minRuntimeVersion"`
+	Notes             []string `json:"notes"`
+	LegacyFilenames   []string `json:"legacyFilenames"`
 }
 
 // LuaRuntime represents the runtime information of the Lua environment.
 type LuaRuntime struct {
-	OsType        string `luai:"osType"`
-	ArchType      string `luai:"archType"`
-	Version       string `luai:"version"`
-	PluginDirPath string `luai:"pluginDirPath"`
+	OsType        string `json:"osType"`
+	ArchType      string `json:"archType"`
+	Version       string `json:"version"`
+	PluginDirPath string `json:"pluginDirPath"`
 }

--- a/internal/luai/decode.go
+++ b/internal/luai/decode.go
@@ -256,7 +256,7 @@ func unmarshalWorker(value lua.LValue, reflected reflect.Value) error {
 
 			for i := 0; i < reflected.NumField(); i++ {
 				fieldTypeField := reflected.Type().Field(i)
-				tag := fieldTypeField.Tag.Get("luai")
+				tag := fieldTypeField.Tag.Get("json")
 				if tag != "" {
 					tagMap[tag] = i
 				}

--- a/internal/luai/encode.go
+++ b/internal/luai/encode.go
@@ -43,7 +43,7 @@ func Marshal(state *lua.LState, v any) (lua.LValue, error) {
 			}
 
 			fieldType := reflected.Type().Field(i)
-			tag := fieldType.Tag.Get("luai")
+			tag := fieldType.Tag.Get("json")
 			if tag == "" {
 				tag = fieldType.Name
 			}

--- a/internal/luai/example_test.go
+++ b/internal/luai/example_test.go
@@ -40,9 +40,9 @@ type testStruct struct {
 }
 
 type testStructTag struct {
-	Field1 string `luai:"field1"`
-	Field2 int    `luai:"field2"`
-	Field3 bool   `luai:"field3"`
+	Field1 string `json:"field1"`
+	Field2 int    `json:"field2"`
+	Field3 bool   `json:"field3"`
 }
 
 type complexStruct struct {
@@ -64,9 +64,9 @@ func TestExample(t *testing.T) {
 		defer L.Close()
 
 		output := struct {
-			Field1  string  `luai:"field1"`
-			Field2  *string `luai:"field2"`
-			AString string  `luai:"a_string"`
+			Field1  string  `json:"field1"`
+			Field2  *string `json:"field2"`
+			AString string  `json:"a_string"`
 		}{}
 
 		if err := L.Instance.DoString(`
@@ -325,7 +325,7 @@ func TestEncodeFunc(t *testing.T) {
 	t.Run("EncodeFunc", func(t *testing.T) {
 		testdata := struct {
 			Func1 func(*lua.LState) int
-			Func2 func(*lua.LState) int `luai:"f2"`
+			Func2 func(*lua.LState) int `json:"f2"`
 		}{
 			Func1: lua.LGFunction(func(L *lua.LState) int {
 				L.Push(lua.LString("hello, world"))

--- a/internal/luai/vm.go
+++ b/internal/luai/vm.go
@@ -18,10 +18,11 @@ package luai
 
 import (
 	_ "embed"
+	"strings"
+
 	"github.com/version-fox/vfox/internal/config"
 	"github.com/version-fox/vfox/internal/module"
 	lua "github.com/yuin/gopher-lua"
-	"strings"
 )
 
 //go:embed fixtures/preload.lua

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -326,7 +326,7 @@ func (m *Manager) LoadAllSdk() ([]*Sdk, error) {
 	}
 
 	sort.Slice(sdkSlice, func(i, j int) bool {
-		return sdkSlice[j].Plugin.SdkName > sdkSlice[i].Plugin.SdkName
+		return sdkSlice[j].Name > sdkSlice[i].Name
 	})
 	return sdkSlice, nil
 }

--- a/internal/package.go
+++ b/internal/package.go
@@ -41,7 +41,7 @@ func newLocationPackage(version Version, sdk *Sdk, location Location) (*Location
 	case GlobalLocation:
 		mockPath = filepath.Join(sdk.InstallPath, "current")
 	case ShellLocation:
-		mockPath = filepath.Join(sdk.sdkManager.PathMeta.CurTmpPath, sdk.Plugin.SdkName)
+		mockPath = filepath.Join(sdk.sdkManager.PathMeta.CurTmpPath, sdk.Name)
 	default:
 		return nil, fmt.Errorf("unknown location: %s", location)
 	}

--- a/internal/package.go
+++ b/internal/package.go
@@ -18,10 +18,11 @@ package internal
 
 import (
 	"fmt"
-	"github.com/version-fox/vfox/internal/logger"
-	"github.com/version-fox/vfox/internal/util"
 	"os"
 	"path/filepath"
+
+	"github.com/version-fox/vfox/internal/logger"
+	"github.com/version-fox/vfox/internal/util"
 )
 
 // LocationPackage represents a package that needs to be linked
@@ -139,11 +140,11 @@ func (p *Package) Clone() *Package {
 }
 
 type Info struct {
-	Name     string            `luai:"name"`
-	Version  Version           `luai:"version"`
-	Path     string            `luai:"path"`
-	Headers  map[string]string `luai:"headers"`
-	Note     string            `luai:"note"`
+	Name     string            `json:"name"`
+	Version  Version           `json:"version"`
+	Path     string            `json:"path"`
+	Headers  map[string]string `json:"headers"`
+	Note     string            `json:"note"`
 	Checksum *Checksum
 }
 

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -61,6 +61,14 @@ var (
 	}
 )
 
+type Plugin interface {
+	Available(args []string) ([]*Package, error)
+	PreInstall(version Version) (*Package, error)
+	PostInstall(rootPath string, sdks []*Info) error
+	EnvKeys(sdkPackage *Package) (*env.Envs, error)
+	Label(version string) string
+}
+
 type LuaPlugin struct {
 	vm        *luai.LuaVM
 	pluginObj *lua.LTable

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -65,8 +65,21 @@ type Plugin interface {
 	Available(args []string) ([]*Package, error)
 	PreInstall(version Version) (*Package, error)
 	PostInstall(rootPath string, sdks []*Info) error
+	PreUninstall(p *Package) error
+	PreUse(version Version, previousVersion Version, scope UseScope, cwd string, installedSdks []*Package) (Version, error)
 	EnvKeys(sdkPackage *Package) (*env.Envs, error)
 	Label(version string) string
+	ParseLegacyFile(path string, installedVersions func() []Version) (Version, error)
+	Close()
+}
+
+type PluginInfo struct {
+	Plugin
+
+	// // plugin filename, this is also alias name, sdk-name
+	// SdkName string
+	// // plugin source path
+	// Path string
 }
 
 type LuaPlugin struct {
@@ -74,8 +87,6 @@ type LuaPlugin struct {
 	pluginObj *lua.LTable
 	// plugin source path
 	Path string
-	// plugin filename, this is also alias name, sdk-name
-	SdkName string
 	*LuaPluginInfo
 }
 
@@ -523,7 +534,6 @@ func NewLuaPlugin(pluginDirPath string, manager *Manager) (*LuaPlugin, error) {
 		vm:        vm,
 		pluginObj: PLUGIN,
 		Path:      pluginDirPath,
-		SdkName:   filepath.Base(pluginDirPath),
 	}
 
 	if err = source.Validate(); err != nil {

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -1,12 +1,13 @@
 package internal
 
 import (
-	"github.com/version-fox/vfox/internal/config"
-	"github.com/version-fox/vfox/internal/util"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/version-fox/vfox/internal/config"
+	"github.com/version-fox/vfox/internal/util"
 
 	_ "embed"
 
@@ -39,15 +40,11 @@ func TestNewLuaPluginWithMain(t *testing.T) {
 			t.Fatalf("expected plugin to be set, got nil")
 		}
 
-		if plugin.SdkName != "java_with_main" {
-			t.Errorf("expected filename 'java', got '%s'", plugin.SdkName)
-		}
-
 		if plugin.Path != pluginPathWithMain {
 			t.Errorf("expected filepath '%s', got '%s'", pluginPathWithMain, plugin.Path)
 		}
 
-		if plugin.Name != "java" {
+		if plugin.Name != "java_with_main" {
 			t.Errorf("expected name 'java', got '%s'", plugin.Name)
 		}
 
@@ -90,16 +87,12 @@ func TestNewLuaPluginWithMetadataAndHooks(t *testing.T) {
 			t.Fatalf("expected plugin to be set, got nil")
 		}
 
-		if plugin.SdkName != "java_with_metadata" {
-			t.Errorf("expected filename 'java', got '%s'", plugin.SdkName)
+		if plugin.Name != "java_with_metadata" {
+			t.Errorf("expected filename 'java', got '%s'", plugin.Name)
 		}
 
 		if plugin.Path != pluginPathWithMetadata {
 			t.Errorf("expected filepath '%s', got '%s'", pluginPathWithMetadata, plugin.Path)
-		}
-
-		if plugin.Name != "java" {
-			t.Errorf("expected name 'java', got '%s'", plugin.Name)
 		}
 
 		if plugin.Version != "0.0.1" {
@@ -386,9 +379,9 @@ func testHookFunc(t *testing.T, factory func() (*Manager, *LuaPlugin, error)) {
 				t.Fatal(err)
 			}
 			if len(sdks) != 0 && firstSdkName == "" {
-				firstSdkName = sdks[0].Plugin.SdkName
+				firstSdkName = sdks[0].Name
 			} else if len(sdks) != 0 {
-				if sdks[0].Plugin.SdkName != firstSdkName {
+				if sdks[0].Name != firstSdkName {
 					t.Errorf("expected sdk sort %v", sdks)
 				}
 			}

--- a/internal/testdata/plugins/java_with_main/main.lua
+++ b/internal/testdata/plugins/java_with_main/main.lua
@@ -16,7 +16,7 @@ RUNTIME = {
 
 PLUGIN = {
     --- Plugin name
-    name = "java",
+    name = "java_with_main",
     --- Plugin author
     author = "Lihan",
     --- Plugin version

--- a/internal/testdata/plugins/java_with_metadata/metadata.lua
+++ b/internal/testdata/plugins/java_with_metadata/metadata.lua
@@ -3,7 +3,7 @@ PLUGIN = {}
 
 --- !!! MUST BE SET !!!
 --- Plugin name
-PLUGIN.name = "java"
+PLUGIN.name = "java_with_metadata"
 --- Plugin version
 PLUGIN.version = "0.0.1"
 -- Repository URL


### PR DESCRIPTION
This change updates the struct tags from `luai` to `json` across multiple files to maintain consistency with JSON serialization standards. This improves interoperability and aligns with common practices in Go for handling JSON data.

Prepare for support js plugin