### PR TITLE
docs: Add Nushell information missing from website & readme

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -46,11 +46,14 @@ echo 'vfox activate fish | source' >> ~/.config/fish/config.fish
 # 对于 PowerShell
 if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }; Add-Content -Path $PROFILE -Value 'Invoke-Expression "$(vfox activate pwsh)"'
 
-# Clink:
+# 对于 Clink:
 # 1. 安装 clink: https://github.com/chrisant996/clink/releases
 #    或者安装 cmder: https://github.com/cmderdev/cmder/releases
 # 2. 找到脚本路径: clink info | findstr scripts
 # 3. 复制 internal/shell/clink_vfox.lua 到脚本路径
+
+# 对于 Nushell:
+vfox activate nushell $nu.default-config-dir | save --append $nu.config-path
 ```
 
 > 请记住重启你的 Shell 以应用更改。

--- a/docs/guides/intro.md
+++ b/docs/guides/intro.md
@@ -38,6 +38,7 @@ through a simple plugin interface.
 | CMD        | ✅       | Only Support `Global` Scope. Not Recommend!!!                                    |
 | Clink      | ✅       |                                                                                  |
 | Cmder      | ✅       |                                                                                  |
+| Nushell    | ✅       |                                                                                  |
 
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ features:
     details: "Simple API, making it easy to add support for new tools!"
     icon: 🔌
   - title: "Shells"
-    details: "Supports Powershell, Bash, ZSH, Fish and Clink, with autocomplete feature."
+    details: "Supports Powershell, Bash, ZSH, Fish, Clink, and Nushell, with autocomplete feature."
     icon: 🐚
   - title: Backwards Compatible
     details: "Support for existing version files .nvmrc, .node-version, .sdkmanrc for smooth migration!"

--- a/docs/zh-hans/guides/intro.md
+++ b/docs/zh-hans/guides/intro.md
@@ -34,6 +34,7 @@ API、配置文件和实现方式（比如，`$PATH`
 | CMD        | ✅       | 仅支持`Global`作用域,不推荐使用!!!                                                         |
 | Clink      | ✅       |                                                                                 |
 | Cmder      | ✅       |                                                                                 |
+| Nushell    | ✅       |                                                                                 |
 
 
 

--- a/docs/zh-hans/guides/quick-start.md
+++ b/docs/zh-hans/guides/quick-start.md
@@ -131,6 +131,12 @@ y
 2. 复制 [clink_vfox.lua](https://github.com/version-fox/vfox/blob/main/internal/shell/clink_vfox.lua) 到脚本目录下，`clink_vfox.lua`脚本只需放置在其中一个目录中，无需放入每个目录。
 3. 重启 Clink 或 Cmder
 
+::: details Nushell
+
+```shell
+vfox activate nushell $nu.default-config-dir | save --append $nu.config-path
+```
+
 :::
 
 然后，打开一个新终端。
@@ -145,7 +151,7 @@ y
 你可以使用 `vfox available` 命令查看所有可用插件。
 :::
 
-```bash 
+```bash
 $ vfox add nodejs
 ```
 

--- a/docs/zh-hans/index.md
+++ b/docs/zh-hans/index.md
@@ -31,7 +31,7 @@ features:
     details: "简单的API, 添加新工具的支持变得轻而易举！"
     icon: 🔌
   - title: "Shells"
-    details: "支持 Powershell、Bash、ZSH、Fish和Clink，并提供补全功能。"
+    details: "支持 Powershell、Bash、ZSH、Fish、Clink和Nushell，并提供补全功能。"
     icon: 🐚
   - title: 向后兼容
     details: "支持从现有配置文件.nvmrc、.node-version、.sdkmanrc平滑迁移！"


### PR DESCRIPTION
This adds Nushell to the website's lists of supported shells, and it also adds Nushell information missing from the Chinese versions of the readme and website (addressing #441).

(I don't know Chinese, but the additions seemed pretty straightforward. Please correct me if anything looks wrong.)