### PR TITLE
feat: the globally effective SDK uses the home directory

### DIFF
--- a/internal/toolset/tool_version.go
+++ b/internal/toolset/tool_version.go
@@ -18,10 +18,16 @@ package toolset
 
 import (
 	"fmt"
+	"github.com/version-fox/vfox/internal/base"
 	"path/filepath"
 )
 
 const filename = ".tool-versions"
+
+type ToolVersionWithScope struct {
+	*ToolVersion
+	base.Location
+}
 
 type MultiToolVersions []*ToolVersion
 


### PR DESCRIPTION
Due to the time-based cleaning mechanism of the temporary directory, the global SDK directory may be affected and changed.

E.g. if you use vfox in a ci environment, every time you start,  the tmp directory will be cleaned up.