### PR TITLE
Fix wrong folding blocks of in Nushell doc

### DIFF
--- a/docs/zh-hans/guides/quick-start.md
+++ b/docs/zh-hans/guides/quick-start.md
@@ -131,6 +131,8 @@ y
 2. 复制 [clink_vfox.lua](https://github.com/version-fox/vfox/blob/main/internal/shell/clink_vfox.lua) 到脚本目录下，`clink_vfox.lua`脚本只需放置在其中一个目录中，无需放入每个目录。
 3. 重启 Clink 或 Cmder
 
+:::
+
 ::: details Nushell
 
 ```shell


### PR DESCRIPTION
- For #461 .
- Fix wrong folding blocks of in Nushell doc.
- Currently, for https://vfox.dev/zh-hans/guides/quick-start.html , the documentation for `Nushell` appears embedded within the documentation for `Clink & Cmder`, which is weird.
- ![image](https://github.com/user-attachments/assets/40a767ac-9efb-4ec0-b227-9b26541c49a2)
- https://vfox.dev/guides/quick-start.html does not have this problem.
- ![image](https://github.com/user-attachments/assets/19aea047-a297-47a9-b31b-5520a4656cd3)


