### PR TITLE
feat: add `vfox install --yes` option for quick installation

### DIFF
--- a/cmd/commands/install.go
+++ b/cmd/commands/install.go
@@ -43,7 +43,7 @@ var Install = &cli.Command{
 		&cli.BoolFlag{
 			Name:    "yes",
 			Aliases: []string{"y"},
-			Usage:   "Automatically answers \"yes\" to all prompts during the installation process.",
+			Usage:   "Quick installation, skip interactive prompts",
 		},
 	},
 	Action:   installCmd,

--- a/cmd/commands/install.go
+++ b/cmd/commands/install.go
@@ -51,11 +51,11 @@ var Install = &cli.Command{
 }
 
 func installCmd(ctx *cli.Context) error {
-	if ctx.Bool("all") {
-		return installAll()
-	}
-
 	yes := ctx.Bool("yes")
+
+	if ctx.Bool("all") {
+		return installAll(yes)
+	}
 
 	args := ctx.Args()
 	if args.First() == "" {
@@ -118,7 +118,7 @@ func installCmd(ctx *cli.Context) error {
 	return nil
 }
 
-func installAll() error {
+func installAll(autoConfirm bool) error {
 	manager := internal.NewSdkManager()
 	defer manager.Close()
 
@@ -134,10 +134,13 @@ func installAll() error {
 	fmt.Println("Install the following plugins and SDKs:")
 	printPlugin(plugins, nil)
 	printSdk(sdks, nil)
-	if result, _ := pterm.DefaultInteractiveConfirm.
-		WithDefaultValue(true).
-		Show("Do you want to install these plugins and SDKs?"); !result {
-		return nil
+
+	if !autoConfirm {
+		if result, _ := pterm.DefaultInteractiveConfirm.
+			WithDefaultValue(true).
+			Show("Do you want to install these plugins and SDKs?"); !result {
+			return nil
+		}
 	}
 
 	var (

--- a/cmd/commands/install.go
+++ b/cmd/commands/install.go
@@ -40,6 +40,11 @@ var Install = &cli.Command{
 			Aliases: []string{"a"},
 			Usage:   "Install all SDK versions recorded in .tool-versions",
 		},
+		&cli.BoolFlag{
+			Name:    "yes",
+			Aliases: []string{"y"},
+			Usage:   "Automatically answers \"yes\" to all prompts during the installation process.",
+		},
 	},
 	Action:   installCmd,
 	Category: CategorySDK,
@@ -49,6 +54,8 @@ func installCmd(ctx *cli.Context) error {
 	if ctx.Bool("all") {
 		return installAll()
 	}
+
+	yes := ctx.Bool("yes")
 
 	args := ctx.Args()
 	if args.First() == "" {
@@ -77,7 +84,7 @@ func installCmd(ctx *cli.Context) error {
 				name = strings.ToLower(argArr[0])
 				version = ""
 			}
-			source, err := manager.LookupSdkWithInstall(name)
+			source, err := manager.LookupSdkWithInstall(name, yes)
 			if err != nil {
 				errorStore.AddAndShow(name, err)
 				continue

--- a/cmd/commands/search.go
+++ b/cmd/commands/search.go
@@ -40,7 +40,7 @@ var Search = &cli.Command{
 func RunSearch(sdkName string, availableArgs []string) error {
 	manager := internal.NewSdkManager()
 	defer manager.Close()
-	source, err := manager.LookupSdkWithInstall(sdkName)
+	source, err := manager.LookupSdkWithInstall(sdkName, false)
 	if err != nil {
 		return fmt.Errorf("%s not supported, error: %w", sdkName, err)
 	}

--- a/docs/usage/core-commands.md
+++ b/docs/usage/core-commands.md
@@ -60,6 +60,8 @@ You can install multiple SDKs at the same time by separating them with space.
 vfox install nodejs@20 golang ...
 ```
 
+:::
+
 ::: tip
 Quick installation, skip interactive prompts​​
 

--- a/docs/usage/core-commands.md
+++ b/docs/usage/core-commands.md
@@ -51,6 +51,7 @@ vfox i <sdk-name>@<version>
 **Options**
 
 - `-a, --all`: Install all SDK versions recorded in .tool-versions
+- `-y, --yes`: Quick installation, skip interactive prompts​
 
 ::: tip
 You can install multiple SDKs at the same time by separating them with space.
@@ -58,6 +59,15 @@ You can install multiple SDKs at the same time by separating them with space.
 ```shell
 vfox install nodejs@20 golang ...
 ```
+
+::: tip
+Quick installation, skip interactive prompts​​
+
+```shell
+vfox install --yes nodejs@20
+vfox install --yes --all
+```
+
 :::
 
 ## Use

--- a/docs/zh-hans/usage/core-commands.md
+++ b/docs/zh-hans/usage/core-commands.md
@@ -53,6 +53,7 @@ vfox i <sdk-name>@<version>
 **选项**
 
 - `-a, --all`: 安装 .tool-versions 中记录的所有 SDK 版本
+- `-y, --yes`: 直接安装，跳过确认提示
 
 ::: tip 自动安装
 你可以一次性安装多个 SDK，通过空格分隔。
@@ -60,6 +61,15 @@ vfox i <sdk-name>@<version>
 ```shell
 vfox install nodejs@20 golang ...
 ```
+
+::: tip
+直接安装，跳过确认提示
+
+```shell
+vfox install --yes nodejs@20
+vfox install --yes --all
+```
+
 :::
 
 ## Use

--- a/docs/zh-hans/usage/core-commands.md
+++ b/docs/zh-hans/usage/core-commands.md
@@ -62,6 +62,8 @@ vfox i <sdk-name>@<version>
 vfox install nodejs@20 golang ...
 ```
 
+:::
+
 ::: tip
 直接安装，跳过确认提示
 

--- a/internal/shell/clink_vfox.lua
+++ b/internal/shell/clink_vfox.lua
@@ -78,7 +78,7 @@ clink.argmatcher('vfox'):nofiles():setdelayinit(function(vfox)
     local vfox_install = clink.argmatcher():nofiles():addarg({
         onadvance = function() return 0 end,
         vfox_sdk_func,
-    }):addflags('--all', '-a', '--help', '-h')
+    }):addflags('--all', '-a', '--yes', '-y', '--help', '-h')
 
     vfox:addarg(
         'add' .. clink.argmatcher():nofiles():addarg({


### PR DESCRIPTION
```
> vfox install nodejs@24
[php] not added yet, confirm that you want to use [php]?
Please confirm [y/N]:
```

```
> vfox install --yes nodejs@24
[nodejs] not added yet, automatically proceeding with installation. 
Downloading vfox-nodejs-0.3.0.zip...
Validating C:\Users\tiany\.version-fox\plugin\vfox-nodejs-0.3.0.zip ...
Plugin info:
Name     -> nodejs
Version  -> 0.3.0
Homepage -> https://github.com/version-fox/vfox-nodejs
Desc     -> Node.js runtime environment.
Add nodejs plugin successfully!
Please use `vfox install nodejs@<version>` to install the version you need.
nodejs@24.5.0 is already installed
```
----
```
> vfox install --all
Install the following plugins and SDKs:
SDK:
  nodejs@21.3.0
Do you want to install these plugins and SDKs? [Y/n]:
```
```
> vfox install --all --yes
Install the following plugins and SDKs:
SDK:
  nodejs@21.3.0
⣽  [1/1] SDK: nodejs@21.3.0 installing... (8s)
```
----
issue #498 