### PR TITLE
fix: remove depracated nushell flag in activation script

### DIFF
--- a/internal/shell/nushell.go
+++ b/internal/shell/nushell.go
@@ -33,7 +33,7 @@ export-env {
 
   # Add a pre_prompt hook that calls the above "updateVfoxEnvironment" function.
   $env.config = ($env.config | upsert hooks.pre_prompt {
-    let currentValue = ($env.config | get -i hooks.pre_prompt)
+    let currentValue = ($env.config | get -o hooks.pre_prompt)
     if $currentValue == null {
       [{updateVfoxEnvironment}]
     } else {


### PR DESCRIPTION
The problem:

<img width="1161" height="222" alt="image" src="https://github.com/user-attachments/assets/43b30c01-12b7-4942-9bce-6b99c6ebebd6" />

Reproduced in nushell 0.106.1

This patch resolves this issue by updating the args