### PR TITLE
refactor: already installed without error

### DIFF
--- a/internal/sdk.go
+++ b/internal/sdk.go
@@ -91,7 +91,8 @@ type Sdk struct {
 func (b *Sdk) Install(version base.Version) error {
 	label := b.Label(version)
 	if b.CheckExists(version) {
-		return fmt.Errorf("%s is already installed", label)
+		fmt.Printf("%s is already installed\n", label)
+		return nil
 	}
 	installInfo, err := b.Plugin.PreInstall(version)
 	if err != nil {
@@ -107,7 +108,8 @@ func (b *Sdk) Install(version base.Version) error {
 	// for example, latest is resolved to a specific version number.
 	label = b.Label(sdkVersion)
 	if b.CheckExists(sdkVersion) {
-		return fmt.Errorf("%s is already installed", label)
+		fmt.Printf("%s is already installed\n", label)
+		return nil
 	}
 	success := false
 	newDirPath := b.VersionPath(sdkVersion)


### PR DESCRIPTION
Already installed version should not prompt installation failure

### before
```
> vfox install nodejs@24
nodejs@24.5.0 is already installed
failed to install nodejs
```

### now
```
> vfox install nodejs@24
nodejs@24.5.0 is already installed
```