### PR TITLE
[Nushell] Change renamed flag

### DIFF
--- a/internal/shell/nushell.go
+++ b/internal/shell/nushell.go
@@ -33,7 +33,7 @@ export-env {
 
   # Add a pre_prompt hook that calls the above "updateVfoxEnvironment" function.
   $env.config = ($env.config | upsert hooks.pre_prompt {
-    let currentValue = ($env.config | get -i hooks.pre_prompt)
+    let currentValue = ($env.config | get -o hooks.pre_prompt)
     if $currentValue == null {
       [{updateVfoxEnvironment}]
     } else {


### PR DESCRIPTION
[Nushell version 0.106.0 renamed flag](https://www.nushell.sh/blog/2025-07-23-nushell_0_106_0.html#ignore-errors-i-renamed-to-optional-o-toc) `--ignore-errors (-i) flag` to `--optional (-o)` to better reflect it's behavior and use terminology consistent with cell-paths.

This PR changes the integration script to reflect this.