### PR TITLE
fix(manager): handle error when creating new SDK instance

### DIFF
--- a/internal/manager.go
+++ b/internal/manager.go
@@ -303,8 +303,7 @@ func (m *Manager) LoadAllSdk() ([]*Sdk, error) {
 			d = fs.FileInfoToDirEntry(dirFileInfo)
 		}
 
-		if d.IsDir() {
-		} else if strings.HasSuffix(sdkName, ".lua") {
+		if !d.IsDir() {
 			logger.Debugf("Found old plugin: %s \n", path)
 			// FIXME !!! This snippet will be removed in a later version
 			// rename old plugin path to new plugin path
@@ -321,7 +320,12 @@ func (m *Manager) LoadAllSdk() ([]*Sdk, error) {
 		} else {
 			continue
 		}
-		sdk, _ := NewSdk(m, path)
+
+		sdk, err := NewSdk(m, path)
+		if err != nil {
+			return nil, err
+		}
+
 		sdkSlice = append(sdkSlice, sdk)
 
 		m.openSdks[strings.ToLower(sdkName)] = sdk

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -303,7 +303,8 @@ func (m *Manager) LoadAllSdk() ([]*Sdk, error) {
 			d = fs.FileInfoToDirEntry(dirFileInfo)
 		}
 
-		if !d.IsDir() {
+		if d.IsDir() {
+		} else if strings.HasSuffix(sdkName, ".lua") {
 			logger.Debugf("Found old plugin: %s \n", path)
 			// FIXME !!! This snippet will be removed in a later version
 			// rename old plugin path to new plugin path


### PR DESCRIPTION
Check and return error from NewSdk instead of ignoring it to prevent potential nil pointer issues

close: https://github.com/version-fox/vfox/issues/520