### PR TITLE
feat(legacy): add strategy support for legacy version file parsing

### DIFF
--- a/internal/base/interfaces.go
+++ b/internal/base/interfaces.go
@@ -202,6 +202,12 @@ type ParseLegacyFileHookCtx struct {
 	Filepath             string           `json:"filepath"`
 	Filename             string           `json:"filename"`
 	GetInstalledVersions func() []Version `json:"getInstalledVersions"`
+	// Support three strategies:
+	// 1. latest_installed: use the latest installed version
+	// 2. latest_available: use the latest available version
+	// 3. specified: use the specified version in the legacy file
+	// default: specified
+	Strategy string `json:"strategy"`
 }
 
 type ParseLegacyFileResult struct {

--- a/internal/config/legacy_version_file.go
+++ b/internal/config/legacy_version_file.go
@@ -16,12 +16,26 @@
 
 package config
 
+const (
+	LatestInstalledStrategy = "latest_installed"
+	LatestAvailableStrategy = "latest_available"
+	SpecifiedStrategy       = "specified"
+	DefaultStrategy         = SpecifiedStrategy
+)
+
 // LegacyVersionFile represents whether to enable the ability to parse legacy version files,
 // Disable by default.
 type LegacyVersionFile struct {
 	Enable bool `yaml:"enable"`
+	// Support three strategies:
+	// 1. latest_installed: use the latest installed version
+	// 2. latest_available: use the latest available version
+	// 3. specified: use the specified version in the legacy file
+	// default: specified
+	Strategy string `yaml:"strategy"`
 }
 
 var EmptyLegacyVersionFile = &LegacyVersionFile{
-	Enable: false,
+	Enable:   false,
+	Strategy: DefaultStrategy,
 }

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -343,6 +343,7 @@ func (l *PluginWrapper) ParseLegacyFile(path string, installedVersions func() []
 			logger.Debugf("Invoking GetInstalledVersions result: %+v \n", versions)
 			return versions
 		},
+		Strategy: l.config.LegacyVersionFile.Strategy,
 	}
 
 	logger.Debugf("ParseLegacyFile: %+v \n", ctx)


### PR DESCRIPTION
Add support for three version selection strategies when parsing legacy version files:
1. latest_installed: use the latest installed version
2. latest_available: use the latest available version
3. specified: use the version specified in the file (default)