### PR TITLE
feat(config): enable legacy version file by default

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -12,12 +12,24 @@ If you use `vfox` for the first time, an empty `config.yaml` file will be create
 Plugins **with support** can read the versions files used by other version managers,
 for example, `.nvmrc` in the case of Nodejs's `nvm`.
 
-This capability is **turned off by default**, you can enable it as follows.
+This capability is **turned on by default**. The related configuration options are as follows:
 
 ```yaml
 legacyVersionFile:
   enable: true
+  strategy: "specified" # Parsing strategy
 ```
+
+- `enable`: Whether to enable legacy version file parsing functionality
+- `strategy`: Parsing strategy, see strategy options below for details
+
+### Strategy Options
+
+`vfox` supports the following three parsing strategies:
+
+- `latest_installed`: Use the latest installed version
+- `latest_available`: Use the latest available version
+- `specified`: Use the version specified in the legacy file (default)
 
 ::: warning
 
@@ -26,6 +38,8 @@ legacyVersionFile:
 2. Enabling this feature may cause `vfox` to refresh environment variables slightly slower, **please enable it according
    to your needs**.
    :::
+
+If you want to disable this feature, you can use the command: `vfox config legacyVersionFile.enable false`
 
 ## Proxy Settings
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -37,7 +37,8 @@ legacyVersionFile:
    directory, `vfox` **priority read** the `.tool-versions` file.
 2. Enabling this feature may cause `vfox` to refresh environment variables slightly slower, **please enable it according
    to your needs**.
-   :::
+
+:::
 
 If you want to disable this feature, you can use the command: `vfox config legacyVersionFile.enable false`
 
@@ -91,15 +92,15 @@ registry:
 cache time is `12h`.
 
 ::: warning Special Value
+
 - `-1`: Never expire
 - `0`: Do not cache
-:::
+  :::
 
 ```yaml
 cache:
   availableHookDuration: 12h # s second, m minute, h hour
 ```
-
 
 ::: tip Cache File Path
 `$HOME/.version-fox/plugins/<plugin-name>/available.cache`

--- a/docs/plugins/create/howto.md
+++ b/docs/plugins/create/howto.md
@@ -233,6 +233,10 @@ This hook is used to parse other configuration files to determine the version of
 This hook must be used with the `legacyFilenames` configuration item to tell `vfox` which files your plugin can parse.
 :::
 
+::: tip Strategy Configuration
+When implementing this hook function, you can access the user-configured parsing strategy through `ctx.strategy`. For detailed strategy configuration, please refer to the [Configuration Documentation](../../guides/configuration.md#legacy-version-file).
+:::
+
 **location**: `metadata.lua`
 
 ```lua
@@ -249,6 +253,8 @@ PLUGIN.legacyFilenames = {
 function PLUGIN:ParseLegacyFile(ctx)
     local filename = ctx.filename
     local filepath = ctx.filepath
+    --- Parsing strategy (latest_installed, latest_available, specified)
+    local strategy = ctx.strategy
     --- Get the list of versions of the current plugin installed
     local versions = ctx:getInstalledVersions()
 

--- a/docs/zh-hans/guides/configuration.md
+++ b/docs/zh-hans/guides/configuration.md
@@ -10,12 +10,24 @@
 
 插件 **支持** 读取其他版本管理器的配置文件, 例如: Nodejs 的`nvm`的`.nvmrc`文件, Java 的`SDKMAN`的`.sdkmanrc`文件等。
 
-此能力**默认是关闭的**, 如果你想开启, 请按照以下方式配置:
+此能力**默认是开启的**。相关配置选项如下:
 
 ```yaml
 legacyVersionFile:
   enable: true
+  strategy: "specified" # 解析策略
 ```
+
+- `enable`: 是否启用 legacy version file 解析功能
+- `strategy`: 解析策略，详见下方策略选项说明
+
+### 策略选项
+
+`vfox` 支持以下三种解析策略：
+
+- `latest_installed`: 使用最新安装的版本
+- `latest_available`: 使用最新可用的版本
+- `specified`: 使用 legacy file 中指定的版本（默认）
 
 ::: warning
 
@@ -23,6 +35,8 @@ legacyVersionFile:
    `vfox` **优先加载**`.tool-versions`文件.
 2. 开启此功能可能会导致`vfox`刷新环境变量时略微变慢, **请根据自己的需求开启**。
    :::
+
+如果你想禁用此功能，可以使用命令：`vfox config legacyVersionFile.enable false`
 
 ## 代理设置
 
@@ -74,19 +88,19 @@ registry:
 `vfox` 默认会缓存`search`命令的结果, 以减少网络请求次数。默认缓存时间为`12h`。
 
 ::: warning 特殊值
+
 - `-1`: 永不过期
 - `0`: 不进行缓存
-:::
+  :::
+
 ```yaml
 cache:
   availableHookDuration: 12h # s 秒, m 分钟, h 小时
 ```
 
-
 ::: tip 缓存文件路径
 `$HOME/.version-fox/plugins/<plugin-name>/available.cache`
 :::
-
 
 ## Config 命令 <Badge type="tip" text=">= 0.4.0" vertical="middle" />
 

--- a/docs/zh-hans/guides/configuration.md
+++ b/docs/zh-hans/guides/configuration.md
@@ -34,7 +34,8 @@ legacyVersionFile:
 1. 如果目录里同时存在`.tool-versions`和其他版本管理器的配置文件(`.nvmrc`, `.sdkmanrc`等),
    `vfox` **优先加载**`.tool-versions`文件.
 2. 开启此功能可能会导致`vfox`刷新环境变量时略微变慢, **请根据自己的需求开启**。
-   :::
+
+:::
 
 如果你想禁用此功能，可以使用命令：`vfox config legacyVersionFile.enable false`
 

--- a/docs/zh-hans/plugins/create/howto.md
+++ b/docs/zh-hans/plugins/create/howto.md
@@ -224,6 +224,10 @@ end
 该钩子函数必须配合 `legacyFilenames` 配置项使用, 告诉`vfox` 你的插件支持解析哪些文件。
 :::
 
+::: tip 策略配置
+在实现此钩子函数时，你可以通过 `ctx.strategy` 获取用户配置的解析策略。详细的策略配置请参考[配置文档](../../guides/configuration.md#兼容版本文件)。
+:::
+
 **位置**: `metadata.lua`
 
 ```lua
@@ -242,6 +246,8 @@ function PLUGIN:ParseLegacyFile(ctx)
     local filename = ctx.filename
     --- 文件路径
     local filepath = ctx.filepath
+    --- 解析策略 (latest_installed, latest_available, specified)
+    local strategy = ctx.strategy
     --- 获取当前插件已安装的版本列表
     local versions = ctx:getInstalledVersions()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,9 +17,10 @@
 package config_test
 
 import (
-	"github.com/version-fox/vfox/internal/config"
 	"os"
 	"testing"
+
+	"github.com/version-fox/vfox/internal/config"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -58,8 +59,8 @@ func TestConfigWithEmpty(t *testing.T) {
 	if c.Storage.SdkPath != "" {
 		t.Fatal("proxy url must be empty")
 	}
-	if c.LegacyVersionFile.Enable != false {
-		t.Fatal("legacy version file enable must be false")
+	if c.LegacyVersionFile.Enable != true {
+		t.Fatal("legacy version file enable must be true")
 	}
 	if c.Registry.Address != "" {
 		t.Fatal("registry address must be empty")

--- a/internal/config/legacy_version_file.go
+++ b/internal/config/legacy_version_file.go
@@ -24,7 +24,6 @@ const (
 )
 
 // LegacyVersionFile represents whether to enable the ability to parse legacy version files,
-// Disable by default.
 type LegacyVersionFile struct {
 	Enable bool `yaml:"enable"`
 	// Support three strategies:

--- a/internal/config/legacy_version_file.go
+++ b/internal/config/legacy_version_file.go
@@ -36,6 +36,6 @@ type LegacyVersionFile struct {
 }
 
 var EmptyLegacyVersionFile = &LegacyVersionFile{
-	Enable:   false,
+	Enable:   true,
 	Strategy: DefaultStrategy,
 }


### PR DESCRIPTION

Add strategy configuration support for legacy version file parsing with three options: latest_installed, latest_available, and specified. Update documentation to reflect these changes and default enable state.