### PR TITLE
bug: don't fail if profile directory doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ echo 'eval "$(vfox activate zsh)"' >> ~/.zshrc
 echo 'vfox activate fish | source' >> ~/.config/fish/config.fish
 
 # For PowerShell:
+if (-not (Test-Path -Path $PROFILE)) { New-Item -Type File -Path $PROFILE -Force }
 echo 'Invoke-Expression "$(vfox activate pwsh)"' >> $PROFILE
 
 # For Clink:


### PR DESCRIPTION
On a brand new clean machine, the $PROFILE directory (`C:\Users\<username>\Documents\PowerShell`) doesn't exist, causing `>> $PROFILE` to fail.

Restore `New-Item -Force` (which was removed in the previous commit) to ensure the directory is created before `>>`.