### PR TITLE
Set `__VFOX_SHELL` in all shell hooks to prevent spawning subprocess on global use

### DIFF
--- a/internal/shell/bash.go
+++ b/internal/shell/bash.go
@@ -27,6 +27,7 @@ const bashHook = `
 {{.EnvContent}}
 
 export __VFOX_PID=$$;
+export __VFOX_SHELL='bash';
 
 _vfox_hook() {
   local previous_exit_status=$?;

--- a/internal/shell/clink.go
+++ b/internal/shell/clink.go
@@ -24,6 +24,7 @@ import (
 
 const clinkHook = `
 {{.EnvContent}}
+set "__VFOX_SHELL=clink"
 "{{.SelfPath}}" env --cleanup > nul 2> nul
 `
 

--- a/internal/shell/fish.go
+++ b/internal/shell/fish.go
@@ -33,6 +33,7 @@ const fishHook = `
 {{.EnvContent}}
 
 set -x -g __VFOX_PID %self;
+set -x -g __VFOX_SHELL 'fish';
 function __vfox_export_eval --on-event fish_prompt;
 	"{{.SelfPath}}" env -s fish | source;
 

--- a/internal/shell/powershell.go
+++ b/internal/shell/powershell.go
@@ -38,6 +38,7 @@ DO NOT PUT IN MODULE.
 {{.EnvContent}}
 
 $env:__VFOX_PID = $pid;
+$env:__VFOX_SHELL = 'pwsh';
 
 # remove any existing dynamic module of vfox
 if ($null -ne (Get-Module -Name "version-fox")) {

--- a/internal/shell/zsh.go
+++ b/internal/shell/zsh.go
@@ -29,6 +29,7 @@ if [[ -z "$__VFOX_PID" || -z "$__VFOX_SHELL" ]]; then
   {{.EnvContent}}
 
   export __VFOX_PID=$$;
+  export __VFOX_SHELL='zsh';
 
   _vfox_hook() {
     trap -- '' SIGINT;


### PR DESCRIPTION
- Fixes #583 .
- Set `__VFOX_SHELL` in all shell hooks to prevent spawning subprocess on global use. 
- I can't find a compilation guide for vfox in README.md, but I think Copilot's explanation makes a lot of sense. Is there any way I can test it beforehand?