### PR TITLE
changed deprecated flag for updated version

### DIFF
--- a/internal/shell/nushell.go
+++ b/internal/shell/nushell.go
@@ -41,7 +41,7 @@ export-env {
 
   # Add a pre_prompt hook that calls the above "updateVfoxEnvironment" function.
   $env.config = ($env.config | upsert hooks.pre_prompt {
-    let currentValue = ($env.config | get -i hooks.pre_prompt)
+    let currentValue = ($env.config | get -o hooks.pre_prompt)
     if $currentValue == null {
       [{updateVfoxEnvironment}]
     } else {


### PR DESCRIPTION
## Issue
Current autogenerated config for nushell produces this warning on load:
```
Warning: nu::parser::deprecated

  ⚠ Flag deprecated.
    ╭─[/home/jay/.config/nushell/vfox.nu:21:43]
 20 │   $env.config = ($env.config | upsert hooks.pre_prompt {
 21 │     let currentValue = ($env.config | get -i hooks.pre_prompt)
    ·                                           ─┬
    ·                                            ╰── get --ignore-errors was deprecated in 0.106.0 and will be removed in a future release.
 22 │     if $currentValue == null {
    ╰────
  help: This flag has been renamed to `--optional (-o)` to better reflect its behavior.
```

## Changes
Updated config generation script to use the appropriate flag