### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/internal/shell/clink.go
+++ b/internal/shell/clink.go
@@ -18,6 +18,7 @@ package shell
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/version-fox/vfox/internal/env"
 )
@@ -48,5 +49,16 @@ func (b clink) Export(envs env.Vars) (out string) {
 }
 
 func (b clink) set(key, value string) string {
-	return fmt.Sprintf("set \"%s=%s\"\n", key, value)
+	return fmt.Sprintf("set \"%s=%s\"\n", escapeCmdSet(key), escapeCmdSet(value))
+}
+
+func escapeCmdSet(value string) string {
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	return strings.NewReplacer(
+		"^", "^^",
+		"\"", "^\"",
+		"%", "%%",
+		"!", "^!",
+	).Replace(value)
 }

--- a/internal/shell/zsh.go
+++ b/internal/shell/zsh.go
@@ -17,8 +17,6 @@
 package shell
 
 import (
-	"fmt"
-
 	"github.com/version-fox/vfox/internal/env"
 )
 
@@ -76,10 +74,6 @@ func (z zsh) Export(envs env.Vars) (out string) {
 }
 
 func (z zsh) export(key, value string) string {
-	// Use double quotes for PATH-like variables to avoid unnecessary ANSI-C quoting
-	if key == "PATH" {
-		return fmt.Sprintf("export %s=\"%s\";", key, value)
-	}
 	return "export " + z.escape(key) + "=" + z.escape(value) + ";"
 }
 


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `internal/shell/zsh.go:L78`

The `zsh.export` method special-cases `PATH` and interpolates it directly into a double-quoted shell assignment (`export PATH="%s";`) without escaping. If a PATH segment contains shell metacharacters or command substitution syntax (e.g., `$(...)` or backticks), it can be evaluated when the activation script is sourced, leading to code execution in the user shell context.

## Solution

Apply the same escaping logic used for other variables to PATH values (or use a robust shell-quoting helper for all vars). Avoid raw interpolation into double quotes.

## Changes

- `internal/shell/zsh.go` (modified)
- `internal/shell/clink.go` (modified)