### PR TITLE
Avoid triggering millions of syscalls when unpacking compressed files like the Flutter SDK

### DIFF
--- a/internal/shared/util/decompressor.go
+++ b/internal/shared/util/decompressor.go
@@ -19,6 +19,7 @@ package util
 import (
 	"archive/tar"
 	"archive/zip"
+	"bufio"
 	"bytes"
 	"compress/bzip2"
 	"compress/gzip"
@@ -127,12 +128,12 @@ func (g *XZTarDecompressor) Decompress(dest string) error {
 		return err
 	}
 	defer file.Close()
-	gzr, err := xz.NewReader(file)
+	xzr, err := xz.NewReader(bufio.NewReader(file))
 	if err != nil {
 		return err
 	}
 
-	tr := tar.NewReader(gzr)
+	tr := tar.NewReader(xzr)
 	var symlinks []symlink
 loop:
 	for {

--- a/internal/shared/util/decompressor_test.go
+++ b/internal/shared/util/decompressor_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
+	"github.com/ulikunitz/xz"
 )
 
 func TestNewDecompressor(t *testing.T) {
@@ -45,6 +46,11 @@ func TestNewDecompressor(t *testing.T) {
 	tzstDecompressor := NewDecompressor("test.tzst")
 	if _, ok := tzstDecompressor.(*ZstdTarDecompressor); !ok {
 		t.Errorf("Expected ZstdTarDecompressor, got %T", tzstDecompressor)
+	}
+
+	xzTarDecompressor := NewDecompressor("test.tar.xz")
+	if _, ok := xzTarDecompressor.(*XZTarDecompressor); !ok {
+		t.Errorf("Expected XZTarDecompressor, got %T", xzTarDecompressor)
 	}
 
 	unknownDecompressor := NewDecompressor("test.unknown")
@@ -143,6 +149,151 @@ func writeZstdTar(t *testing.T, archivePath string, name string, body string) {
 		t.Fatal(err)
 	}
 	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestXZTarDecompressor(t *testing.T) {
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "test.tar.xz")
+	dest := filepath.Join(tempDir, "dest")
+	body := "Hello, xz!"
+
+	writeXzTar(t, archivePath, "test.txt", body)
+
+	decompressor := NewDecompressor(archivePath)
+	if err := decompressor.Decompress(dest); err != nil {
+		t.Fatalf("Failed to decompress: %v", err)
+	}
+
+	decompressedFile, err := os.ReadFile(filepath.Join(dest, "test.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(decompressedFile)) != body {
+		t.Errorf("Expected %q, got %q", body, string(decompressedFile))
+	}
+}
+
+func TestXZTarDecompressorStripsCommonRootFolder(t *testing.T) {
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "test.tar.xz")
+	dest := filepath.Join(tempDir, "dest")
+	body := "Hello from root!"
+
+	writeXzTar(t, archivePath, "root/test.txt", body)
+
+	decompressor := NewDecompressor(archivePath)
+	if err := decompressor.Decompress(dest); err != nil {
+		t.Fatalf("Failed to decompress: %v", err)
+	}
+
+	decompressedFile, err := os.ReadFile(filepath.Join(dest, "test.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(decompressedFile)) != body {
+		t.Errorf("Expected %q, got %q", body, string(decompressedFile))
+	}
+}
+
+func TestXZTarDecompressorMultipleFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "test.tar.xz")
+	dest := filepath.Join(tempDir, "dest")
+
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	xw, err := xz.NewWriter(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw := tar.NewWriter(xw)
+
+	files := []struct {
+		Name, Body string
+	}{
+		{"root/a.txt", "content-a"},
+		{"root/b.txt", "content-b"},
+		{"root/sub/c.txt", "content-c"},
+	}
+	for _, f := range files {
+		err = tw.WriteHeader(&tar.Header{
+			Name:     f.Name,
+			Mode:     0600,
+			Size:     int64(len(f.Body)),
+			Typeflag: tar.TypeReg,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(f.Body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := xw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	decompressor := NewDecompressor(archivePath)
+	if err := decompressor.Decompress(dest); err != nil {
+		t.Fatalf("Failed to decompress: %v", err)
+	}
+
+	for _, f := range files {
+		// root/ prefix is stripped by decompressor
+		stripped := strings.TrimPrefix(f.Name, "root/")
+		content, err := os.ReadFile(filepath.Join(dest, stripped))
+		if err != nil {
+			t.Fatalf("Failed to read %s: %v", stripped, err)
+		}
+		if string(content) != f.Body {
+			t.Errorf("File %s: expected %q, got %q", stripped, f.Body, string(content))
+		}
+	}
+}
+
+func writeXzTar(t *testing.T, archivePath string, name string, body string) {
+	t.Helper()
+
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	xw, err := xz.NewWriter(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw := tar.NewWriter(xw)
+
+	err = tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     0600,
+		Size:     int64(len(body)),
+		Typeflag: tar.TypeReg,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte(body)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := xw.Close(); err != nil {
 		t.Fatal(err)
 	}
 	if err := file.Close(); err != nil {


### PR DESCRIPTION
- Fixes https://github.com/version-fox/vfox-flutter/issues/7 .
- Avoid triggering millions of syscalls when unpacking compressed files like the Flutter SDK.
- `internal/shared/util/decompressor.go:131` — `XZTarDecompressor` directly passes the raw `*os.File` to `xz.NewReader()`. The `LZMA2` decoder in the `ulikunitz/xz` library reads byte by byte through the `ByteReader` interface. Because `os.File` is unbuffered, a syscall is triggered for each byte. The Flutter SDK's corresponding file, https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.44.0-stable.tar.xz , is approximately 1.4 GB; its decompression process generates millions of syscalls, resulting in extreme slowness.
- The early investigation is located at https://github.com/apache/incubator-ponymail-foal/issues/310 .