### PR TITLE
fix(util): reject path traversal in all archive extractors

### DIFF
--- a/internal/shared/util/decompressor.go
+++ b/internal/shared/util/decompressor.go
@@ -81,6 +81,9 @@ loop:
 		fname := strings.Join(parts, "/")
 
 		target := filepath.Join(dest, fname)
+		if err := ensureWithinDest(dest, target); err != nil {
+			return err
+		}
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if _, err := os.Stat(target); err != nil {
@@ -156,6 +159,9 @@ loop:
 		fname := strings.Join(parts, "/")
 
 		target := filepath.Join(dest, fname)
+		if err := ensureWithinDest(dest, target); err != nil {
+			return err
+		}
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if _, err := os.Stat(target); err != nil {
@@ -227,6 +233,9 @@ loop:
 		}
 		fname := strings.Join(parts, "/")
 		target := filepath.Join(dest, fname)
+		if err := ensureWithinDest(dest, target); err != nil {
+			return err
+		}
 
 		switch header.Typeflag {
 		case tar.TypeDir:
@@ -384,6 +393,19 @@ func findRootFolderInZstdTar(tarFilePath string) string {
 	return firstElement
 }
 
+// ensureWithinDest verifies that target does not escape dest via ".." path
+// components, guarding against archive path traversal (Zip Slip).
+func ensureWithinDest(dest, target string) error {
+	rel, err := filepath.Rel(dest, target)
+	if err != nil {
+		return err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("archive entry %q is outside destination", target)
+	}
+	return nil
+}
+
 func safeZstdTarTarget(dest string, name string, rootFolderInTar string) (string, error) {
 	normalizedPath := strings.ReplaceAll(name, "\\", "/")
 	if strings.HasPrefix(normalizedPath, "/") {
@@ -493,6 +515,9 @@ func (z *ZipDecompressor) processZipFile(f *zip.File, dest string, rootFolderInZ
 	fname := strings.Join(parts, "/")
 
 	fpath := filepath.Join(dest, fname)
+	if err := ensureWithinDest(dest, fpath); err != nil {
+		return err
+	}
 	if f.FileInfo().IsDir() || isDir(fname) {
 		err := os.MkdirAll(fpath, os.ModePerm)
 		if err != nil {
@@ -625,6 +650,9 @@ func (s *SevenZipDecompressor) extractFile(f *sevenzip.File, dest string, rootFo
 	fname := strings.Join(parts, "/")
 
 	fpath := filepath.Join(dest, fname)
+	if err := ensureWithinDest(dest, fpath); err != nil {
+		return err
+	}
 	if f.FileInfo().IsDir() || isDir(fname) {
 		err := os.MkdirAll(fpath, os.ModePerm)
 		if err != nil {

--- a/internal/shared/util/decompressor.go
+++ b/internal/shared/util/decompressor.go
@@ -398,7 +398,10 @@ func findRootFolderInZstdTar(tarFilePath string) string {
 func ensureWithinDest(dest, target string) error {
 	rel, err := filepath.Rel(dest, target)
 	if err != nil {
-		return err
+		// filepath.Rel fails when the paths share no common base (for
+		// example different volumes or UNC paths on Windows). Treat that as
+		// an escape rather than leaking the low-level error to the caller.
+		return fmt.Errorf("archive entry %q is outside destination", target)
 	}
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 		return fmt.Errorf("archive entry %q is outside destination", target)

--- a/internal/shared/util/decompressor_test.go
+++ b/internal/shared/util/decompressor_test.go
@@ -436,3 +436,20 @@ func writeXzTar(t *testing.T, archivePath string, name string, body string) {
 //		}
 //	}
 //}
+
+func TestEnsureWithinDestWrapsRelError(t *testing.T) {
+	// filepath.Rel fails when target cannot be made relative to dest (for
+	// example an absolute target against a relative dest, or different
+	// volumes on Windows). ensureWithinDest must return the consistent
+	// "outside destination" error instead of leaking the low-level Rel error.
+	err := ensureWithinDest("relative/dest", "/abs/target")
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "outside destination") {
+		t.Errorf("expected an outside destination error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "Rel:") {
+		t.Errorf("raw filepath.Rel error leaked to caller: %v", err)
+	}
+}

--- a/internal/shared/util/decompressor_test.go
+++ b/internal/shared/util/decompressor_test.go
@@ -264,6 +264,22 @@ func TestXZTarDecompressorMultipleFiles(t *testing.T) {
 	}
 }
 
+func TestXZTarDecompressorRejectsPathTraversal(t *testing.T) {
+	tempDir := t.TempDir()
+	archivePath := filepath.Join(tempDir, "test.tar.xz")
+	dest := filepath.Join(tempDir, "dest")
+
+	writeXzTar(t, archivePath, "root/../../evil.txt", "evil")
+
+	decompressor := NewDecompressor(archivePath)
+	if err := decompressor.Decompress(dest); err == nil {
+		t.Fatal("Expected path traversal archive entry to fail")
+	}
+	if _, err := os.Stat(filepath.Join(tempDir, "evil.txt")); !os.IsNotExist(err) {
+		t.Fatalf("Expected no file outside destination, got err %v", err)
+	}
+}
+
 func writeXzTar(t *testing.T, archivePath string, name string, body string) {
 	t.Helper()
 


### PR DESCRIPTION
The zstd tar extractor validates that each entry stays inside the destination via safeZstdTarTarget, but the gzip, xz, bzip2, zip and 7z extractors join the entry name onto dest and write it without that check, so an archive with ../ entries can write files outside the target directory. This adds a shared containment check to every extractor and a regression test for the xz tar path.