### PR TITLE
fix: infinite loop on `vfox config` with no args

### DIFF
--- a/cmd/commands/config.go
+++ b/cmd/commands/config.go
@@ -50,7 +50,7 @@ func configCmd(ctx context.Context, cmd *cli.Command) error {
 
 	args := cmd.Args()
 	if args.Len() == 0 {
-		return cmd.Run(ctx, []string{"CMD", "config", "-h"})
+		return cli.ShowSubcommandHelp(cmd)
 	}
 
 	keys := strings.Split(args.First(), ".")


### PR DESCRIPTION
Running `vfox config` without arguments caused the process to hang wasting CPU and no output

`cmd.Run(ctx, []string{"CMD", "config", "-h"})` re-enters the config command's own action instead of showing help, recursing forever

Show the help directly via `cli.ShowSubcommandHelp` instead