### PR TITLE
Supports installing vfox via DEB822 format

### DIFF
--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -47,6 +47,20 @@ sudo apt-get install vfox
 ```
 
 </TabItem>
+<TabItem label="DEB822 (Debian/Ubuntu)">
+
+```shell
+sudo tee /etc/apt/sources.list.d/versionfox.sources <<EOF
+Types: deb
+URIs: https://apt.fury.io/versionfox/
+Suites: /
+Signed-By: /dev/null
+EOF
+sudo apt-get update -o Acquire::AllowReleaseNoSignature=true -o Acquire::AllowInsecureRepositories=true
+sudo apt-get install vfox --allow-unauthenticated
+```
+
+</TabItem>
 <TabItem label="YUM (CentOS/Fedora)">
 
 ```shell

--- a/docs/guides/uninstallation.md
+++ b/docs/guides/uninstallation.md
@@ -158,10 +158,16 @@ brew uninstall vfox
 sudo apt-get remove vfox
 ```
 
-To also remove the repository configuration:
+To also remove the repository configuration (legacy format):
 
 ```shell
 sudo rm /etc/apt/sources.list.d/versionfox.list
+```
+
+If using DEB822 format:
+
+```shell
+sudo rm /etc/apt/sources.list.d/versionfox.sources
 ```
 
 :::

--- a/docs/zh-hans/guides/quick-start.md
+++ b/docs/zh-hans/guides/quick-start.md
@@ -47,6 +47,20 @@ sudo apt-get install vfox
 ```
 
 </TabItem>
+<TabItem label="DEB822 (Debian/Ubuntu)">
+
+```shell
+sudo tee /etc/apt/sources.list.d/versionfox.sources <<EOF
+Types: deb
+URIs: https://apt.fury.io/versionfox/
+Suites: /
+Signed-By: /dev/null
+EOF
+sudo apt-get update -o Acquire::AllowReleaseNoSignature=true -o Acquire::AllowInsecureRepositories=true
+sudo apt-get install vfox --allow-unauthenticated
+```
+
+</TabItem>
 <TabItem label="YUM (CentOS/Fedora)">
 
 ```shell

--- a/docs/zh-hans/guides/uninstallation.md
+++ b/docs/zh-hans/guides/uninstallation.md
@@ -158,10 +158,16 @@ brew uninstall vfox
 sudo apt-get remove vfox
 ```
 
-同时删除仓库配置：
+同时删除仓库配置（传统格式）：
 
 ```shell
 sudo rm /etc/apt/sources.list.d/versionfox.list
+```
+
+如果使用 DEB822 格式：
+
+```shell
+sudo rm /etc/apt/sources.list.d/versionfox.sources
 ```
 
 :::


### PR DESCRIPTION
- Fixes https://github.com/version-fox/vfox/issues/625 .
- Supports installing vfox via DEB822 format. 
- This is a documentation issue; I've tested it locally in a temporary Docker container. The Fury repository uses a flat layout (containing only `Packages.gz` and no `Release` file), so the APT configuration requires additional settings; otherwise, `apt-get update` will fail with an error. To be honest, I don't think I can change the decision to use the Fury repository.