### PR TITLE
Add Windows installation packages in `.msixbundle` format

### DIFF
--- a/.github/workflows/compile-msix.yml
+++ b/.github/workflows/compile-msix.yml
@@ -1,0 +1,57 @@
+name: compile-msix
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: write
+  id-token: write
+  packages: write
+
+jobs:
+  compile-msix:
+    name: Build MSIX bundle and publish
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: packaging/msix
+    steps:
+      - name: Checkout version-fox
+        uses: actions/checkout@v7
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+      - name: Decode signing certificate
+        env:
+          MSIX_PFX_BASE64: ${{ secrets.MSIX_PFX_BASE64 }}
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrEmpty($env:MSIX_PFX_BASE64)) {
+            Write-Host "MSIX_PFX_BASE64 not configured; the bundle will be published unsigned."
+            exit 0
+          }
+          [IO.File]::WriteAllBytes((Join-Path (Get-Location) "signing.pfx"), [Convert]::FromBase64String($env:MSIX_PFX_BASE64))
+      # No inputs: make-msix.ps1 reads the version from internal/version.go
+      # and builds every architecture from source itself.
+      - name: Build MSIX bundle
+        env:
+          MSIX_SIGN_PFX_PASSWORD: ${{ secrets.MSIX_PFX_PASSWORD }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $tagVersion = "${{ github.event.release.tag_name }}" -replace '^v', ''
+          $sourceVersion = (Select-String -Path "../../internal/version.go" -Pattern 'RuntimeVersion\s*=\s*"([^"]+)"').Matches[0].Groups[1].Value
+          if ($tagVersion -ne $sourceVersion) {
+            throw "Version mismatch: release tag is '$tagVersion' but internal/version.go says '$sourceVersion'."
+          }
+          ./make-msix.ps1
+      - name: Upload MSIX Assets
+        uses: version-fox/vfox-release-assets@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_id: ${{ github.event.release.id }}
+          assets_path: packaging/msix/Output/*.msixbundle

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -47,6 +47,34 @@ jobs:
           name: test-results-windows-${{ matrix.go-version }}
           path: ${{ runner.temp }}\.vfox
 
+  test-msix-windows:
+    name: Test MSIX packaging on Windows
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24'
+      - name: Check Go installation
+        run: go version
+      # Build, pack, sign, install and verify the .msixbundle end-to-end
+      - name: Run MSIX packaging integration tests
+        shell: pwsh
+        run: |
+          cd ${{ github.workspace }}
+          $ErrorActionPreference = "Stop"
+          & .\scripts\e2e-msix-test.ps1
+        env:
+          VFOX_HOME: ${{ runner.temp }}\.vfox
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-msix-windows
+          path: msix-e2e-out
+
   test-unix:
     name: Test on Unix
     runs-on: ${{ matrix.os }}
@@ -89,7 +117,7 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [test-windows, test-unix]
+    needs: [test-windows, test-unix, test-msix-windows]
     if: always()
 
     steps:
@@ -101,6 +129,7 @@ jobs:
           echo "E2E Tests Summary"
           echo "================"
           echo "Windows tests: $(ls -d test-results-windows-* 2>/dev/null | wc -l) platform(s)"
+          echo "MSIX packaging tests: $(ls -d test-results-msix-windows-* 2>/dev/null | wc -l) platform(s)"
           echo "Unix tests: $(ls -d test-results-* 2>/dev/null | grep -v windows | wc -l) platform(s)"
           echo ""
           echo "All test artifacts have been uploaded."

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ coverage.out
 
 .vfox
 .gocache
+
+# MSIX packaging artifacts
+packaging/msix/Output/
+packaging/msix/staging/
+packaging/msix/assets/
+packaging/msix/build/
+packaging/msix/signing.pfx
+/msix-e2e-out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,3 +132,4 @@ java = { version = "21", vendor = "openjdk" }
 | Shell initialization and exports | [shell/](internal/shell/) |
 | vfox settings | [config/](internal/config/) |
 | Shared utilities | [shared/](internal/shared/) |
+| Windows MSIX packaging | [packaging/msix/](packaging/msix/) (`AppxManifest.xml`, `make-msix.ps1`, `gen-assets.ps1`; docs at [msix.md](docs/guides/msix.md); release via [compile-msix.yml](.github/workflows/compile-msix.yml), e2e via [e2e-msix-test.ps1](scripts/e2e-msix-test.ps1)) |

--- a/cmd/commands/upgrade.go
+++ b/cmd/commands/upgrade.go
@@ -112,6 +112,15 @@ func downloadFile(c *http.Client, filepath string, url string) error {
 }
 
 func upgradeCmd(ctx context.Context, cmd *cli.Command) error {
+	exePath, err := os.Executable()
+	if err != nil {
+		return cli.Exit("Failed to get executable path: "+err.Error(), 1)
+	}
+	// An MSIX-installed vfox lives in the read-only WindowsApps directory;
+	// self-upgrading cannot replace the binary there.
+	if runtime.GOOS == "windows" && strings.Contains(strings.ToLower(exePath), `\windowsapps\`) {
+		return cli.Exit("vfox was installed as an MSIX package and cannot self-upgrade. Install a newer .msixbundle to upgrade.", 1)
+	}
 	manager, err := internal.NewSdkManager()
 	if err != nil {
 		return err
@@ -131,10 +140,6 @@ func upgradeCmd(ctx context.Context, cmd *cli.Command) error {
 	}
 	if err = RequestPermission(); err != nil {
 		return err
-	}
-	exePath, err := os.Executable()
-	if err != nil {
-		return cli.Exit("Failed to get executable path: "+err.Error(), 1)
 	}
 	exeDir, exeName := filepath.Split(exePath)
 	binURL, diffURL := generateUrls(currVersion, latestVersion)

--- a/docs/.vitepress/en.ts
+++ b/docs/.vitepress/en.ts
@@ -93,6 +93,7 @@ function sidebar(): DefaultTheme.Sidebar {
         {
             text: 'Misc',
             items: [
+                {text: 'MSIX Bundle', link: '/guides/msix'},
             ]
         },
     ]

--- a/docs/.vitepress/zh.ts
+++ b/docs/.vitepress/zh.ts
@@ -101,6 +101,7 @@ function sidebar(): DefaultTheme.Sidebar {
         {
             text: '其他',
             items: [
+                {text: 'MSIX 安装包', link: '/zh-hans/guides/msix'},
             ]
         },
     ]

--- a/docs/guides/msix.md
+++ b/docs/guides/msix.md
@@ -1,0 +1,75 @@
+# MSIX Bundle
+
+The Windows assets on the [Releases](https://github.com/version-fox/vfox/releases) page include a `.msixbundle` package in addition to the setup `.exe`. MSIX is Microsoft's current application deployment format, intended to replace `.msi`/`.exe` installers. A bundle contains builds for `x86`, `x64` and `arm64`; Windows selects the matching architecture at install time.
+
+## Requirements
+
+- Windows 10 (1809+) or Windows Server 2025+
+- Optional: [App Installer](https://learn.microsoft.com/windows/msix/app-installer/installing-apps-pkg) for double-click installation
+
+## Installation
+
+Download the latest `vfox_<version>_windows.msixbundle` from the [Releases](https://github.com/version-fox/vfox/releases) page and install it by double-click, or from PowerShell:
+
+```powershell
+Add-AppxPackage -Path .\vfox_<version>_windows.msixbundle
+```
+
+The package registers an app execution alias for `vfox.exe`, so the `vfox` command is available on PATH after installation without further configuration.
+
+::: warning ⚠️ Release bundles are currently unsigned
+Windows refuses to install unsigned packages. Re-sign the bundle with your own certificate before installing (see below).
+:::
+
+### Signing an unsigned bundle
+
+The build cannot perform signing on behalf of users. At install time Windows verifies the signer against certificates trusted on the target machine, so a certificate generated during packaging is treated the same as no signature at all. In addition, MSIX requires an upgrade package to be signed with the same certificate as the installed one; per-build certificates would therefore break upgrades. Signing with a long-lived certificate of your own is a one-time operation: once the certificate is trusted, subsequent versions install without extra steps.
+
+First create a self-signed code-signing certificate whose subject matches the package publisher (`CN=VersionFox`) and import it into the trusted store. Importing into `Cert:\LocalMachine\TrustedPeople` requires an elevated (administrator) PowerShell session:
+
+```powershell
+$cert = New-SelfSignedCertificate -Type Custom -Subject "CN=VersionFox" `
+    -KeyUsage DigitalSignature -CertStoreLocation "Cert:\CurrentUser\My" `
+    -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")
+$password = ConvertTo-SecureString -String "pick-a-password" -Force -AsPlainText
+Export-PfxCertificate -Cert $cert -FilePath vfox.pfx -Password $password | Out-Null
+Import-PfxCertificate -FilePath vfox.pfx -CertStoreLocation Cert:\LocalMachine\TrustedPeople -Password $password
+```
+
+Then sign the bundle and install it ([signtool](https://learn.microsoft.com/windows/win32/seccrypto/signtool) comes with the Windows SDK):
+
+```powershell
+signtool sign /fd SHA256 /f vfox.pfx /p pick-a-password .\vfox_<version>_windows.msixbundle
+Add-AppxPackage -Path .\vfox_<version>_windows.msixbundle
+```
+
+## Uninstallation
+
+```powershell
+Get-AppxPackage *vfox* | Remove-AppxPackage
+```
+
+Alternatively open **Settings** > **Apps** > **Installed apps**, select **vfox** and click **Uninstall**. Uninstalling removes the execution alias together with the package; the `~/.vfox` data directory is kept.
+
+## Notes for maintainers
+
+Release bundles are built by the `compile-msix` workflow on every release. Signing is optional; two options:
+
+- **Self-signed certificate (no external account needed).** Generate one PFX and keep it stable across releases, then configure the repository secrets `MSIX_PFX_BASE64` (Base64-encoded certificate) and `MSIX_PFX_PASSWORD`; the subject must match the manifest publisher (`CN=VersionFox`). Releases are signed automatically from then on. Publish the public `.cer` file alongside the releases so users only need to import it once — because the signature stays identical across versions, upgrades are unaffected.
+- **Publicly trusted certificate.** Packages signed by a CA-issued code-signing certificate or through [Azure Trusted Signing](https://learn.microsoft.com/azure/trusted-signing/overview) install without any user-side trust configuration. Obtaining one involves identity verification, and OV/EV certificates mandate hardware-protected private keys, which cannot be placed in CI secrets.
+
+All packaging files reside in the [`packaging/msix/`](https://github.com/version-fox/vfox/tree/main/packaging/msix) directory:
+
+| File | Purpose |
+|------|---------|
+| `AppxManifest.xml` | Manifest template; `@@VERSION@@`, `@@ARCHITECTURE@@` and `@@PUBLISHER@@` are substituted at build time. |
+| `gen-assets.ps1` | Generates the tile icons from the repository logo (`logo.png`) via System.Drawing: transparent margins are cropped and the artwork is scaled onto a transparent canvas. PNG is required by AppX deployment (SVG is rejected), so these binaries are generated at build time instead of being committed. |
+| `make-msix.ps1` | Builds `vfox` from source with Go, renders the manifest for each architecture, packs them with `MakeAppx.exe`, combines the packages into a `.msixbundle` and optionally signs it with `SignTool.exe`. |
+
+Local packaging requires Windows, the [Windows SDK](https://developer.microsoft.com/windows/downloads/windows-sdk/) (provides `MakeAppx.exe` / `SignTool.exe`) and [Go](https://go.dev/dl/). The script takes no parameters: it reads the version from `internal/version.go`, so a locally built bundle always matches the source tree:
+
+```powershell
+./packaging/msix/make-msix.ps1
+```
+
+Artifacts are written to `packaging/msix/Output/`; `assets/`, `staging/` and `build/` are scratch directories and gitignored. Only stable versions without prerelease or build metadata are supported; they are normalized to four-part versions (`1.2.3` → `1.2.3.0`).

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -26,6 +26,21 @@ winget install vfox
 Go to the [Releases](https://github.com/version-fox/vfox/releases) page to download the latest version of the `setup` installer, then follow the installation wizard to install.
 
 </TabItem>
+<TabItem label="MSIX Bundle">
+
+Go to the [Releases](https://github.com/version-fox/vfox/releases) page to download the latest version of the `.msixbundle` package, then install it with [App Installer](https://learn.microsoft.com/windows/msix/app-installer/installing-apps-pkg) or PowerShell:
+
+```powershell
+Add-AppxPackage -Path .\vfox_<version>_windows.msixbundle
+```
+
+The package registers an [app execution alias](https://learn.microsoft.com/windows/apps/desktop/modernize/desktop-to-uwp-extensions) for `vfox.exe`, so the `vfox` command is available on PATH after installation without further configuration. Requires Windows 10 (1809+) or Windows Server 2025+.
+
+::: warning ⚠️ Unsigned Packages
+Release `.msixbundle` artifacts are currently unsigned, and Windows blocks installation of unsigned packages. Re-sign the bundle with your own certificate first; see [MSIX Bundle](./msix.md) for the detailed steps.
+:::
+
+</TabItem>
 </Tabs>
 
 ### Unix-like

--- a/docs/guides/uninstallation.md
+++ b/docs/guides/uninstallation.md
@@ -131,6 +131,16 @@ winget uninstall vfox
 
 :::
 
+::: details MSIX Bundle
+
+```powershell
+Get-AppxPackage *vfox* | Remove-AppxPackage
+```
+
+Alternatively open **Settings** > **Apps** > **Installed apps**, select **vfox** and click **Uninstall**. Uninstalling also removes the `vfox` app execution alias.
+
+:::
+
 ::: details Manual Installation
 
 1. Delete the directory where you extracted vfox

--- a/docs/zh-hans/guides/msix.md
+++ b/docs/zh-hans/guides/msix.md
@@ -1,0 +1,75 @@
+# MSIX 安装包
+
+[Releases](https://github.com/version-fox/vfox/releases) 页面的 Windows 资产中，除 setup `.exe` 安装器外还提供 `.msixbundle` 安装包。MSIX 是微软当前的应用部署格式，用于取代 `.msi`/`.exe` 安装器。一个 bundle 内含 `x86`、`x64`、`arm64` 三种架构的构建，安装时由 Windows 自动选择匹配的架构。
+
+## 环境要求
+
+- Windows 10（1809+）或 Windows Server 2025+
+- 可选：[应用安装程序](https://learn.microsoft.com/windows/msix/app-installer/installing-apps-pkg)（用于双击安装）
+
+## 安装
+
+从 [Releases](https://github.com/version-fox/vfox/releases) 页面下载最新版本的 `vfox_<version>_windows.msixbundle`，双击安装，或在 PowerShell 中执行：
+
+```powershell
+Add-AppxPackage -Path .\vfox_<version>_windows.msixbundle
+```
+
+安装包会注册 `vfox.exe` 的应用执行别名，因此安装完成后 `vfox` 命令即可直接使用，无需手动配置 PATH。
+
+::: warning ⚠️ 当前发布的安装包未签名
+Windows 会拒绝安装未签名包。安装前请先使用自己的证书对安装包重新签名（方法见下文）。
+:::
+
+### 为未签名安装包签名
+
+构建过程无法代替用户完成签名。Windows 在安装时校验签名证书是否属于目标机器信任的证书，打包阶段生成的临时证书与不签名效果相同；此外 MSIX 要求升级包与已安装包使用同一证书签名，每次构建使用不同证书会导致无法覆盖升级。因此应使用一张长期持有的证书完成签名：证书受信任后，后续版本均可直接安装。
+
+首次操作需创建一张主题与包发布者（`CN=VersionFox`）一致的自签名代码签名证书，并导入本机受信任存储。导入 `Cert:\LocalMachine\TrustedPeople` 需要以管理员身份运行 PowerShell：
+
+```powershell
+$cert = New-SelfSignedCertificate -Type Custom -Subject "CN=VersionFox" `
+    -KeyUsage DigitalSignature -CertStoreLocation "Cert:\CurrentUser\My" `
+    -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")
+$password = ConvertTo-SecureString -String "pick-a-password" -Force -AsPlainText
+Export-PfxCertificate -Cert $cert -FilePath vfox.pfx -Password $password | Out-Null
+Import-PfxCertificate -FilePath vfox.pfx -CertStoreLocation Cert:\LocalMachine\TrustedPeople -Password $password
+```
+
+随后对安装包签名并安装（[signtool](https://learn.microsoft.com/windows/win32/seccrypto/signtool) 随 Windows SDK 提供）：
+
+```powershell
+signtool sign /fd SHA256 /f vfox.pfx /p pick-a-password .\vfox_<version>_windows.msixbundle
+Add-AppxPackage -Path .\vfox_<version>_windows.msixbundle
+```
+
+## 卸载
+
+```powershell
+Get-AppxPackage *vfox* | Remove-AppxPackage
+```
+
+也可以在 **设置** > **应用** > **已安装的应用** 中选择 **vfox** 并点击 **卸载**。卸载会同时移除应用执行别名；`~/.vfox` 数据目录会被保留。
+
+## 维护者须知
+
+发布版 bundle 由 `compile-msix` 工作流在每次 release 时构建。签名可选，有两种方式：
+
+- **自签证书（无需外部账号）**：生成一张 PFX 证书并在各次发布间保持不变，然后配置仓库 secrets：`MSIX_PFX_BASE64`（Base64 编码的证书文件）与 `MSIX_PFX_PASSWORD`；证书主题必须与清单中的发布者一致（`CN=VersionFox`）。此后每次发布都会自动签名。同时将公开证书（`.cer` 文件）随 release 一并分发，用户只需导入一次；由于各版本签名保持一致，覆盖升级不受影响。
+- **受信 CA 证书**：由公共 CA 签发的代码签名证书或 [Azure Trusted Signing](https://learn.microsoft.com/azure/trusted-signing/overview) 服务签名的包，用户机器默认信任，安装时无需任何额外配置。但证书申请需要实名验证，OV/EV 证书的私钥按规定必须保存在硬件介质中，无法放入 CI secrets。
+
+打包相关文件位于仓库的 [`packaging/msix/`](https://github.com/version-fox/vfox/tree/main/packaging/msix) 目录：
+
+| 文件 | 用途 |
+|------|------|
+| `AppxManifest.xml` | 清单模板；`@@VERSION@@`、`@@ARCHITECTURE@@`、`@@PUBLISHER@@` 在构建时替换。 |
+| `gen-assets.ps1` | 通过 System.Drawing 从仓库 logo（`logo.png`）生成磁贴图标：裁剪透明边距并将图案缩放至透明画布。PNG 是 AppX 部署的强制要求（不支持 SVG），因此这些二进制文件不入库，在每次构建时重新生成。 |
+| `make-msix.ps1` | 使用 Go 从源码构建 `vfox`，为每种架构渲染清单，经 `MakeAppx.exe` 打包后合并为 `.msixbundle`，并可选通过 `SignTool.exe` 签名。 |
+
+本地打包需要 Windows、[Windows SDK](https://developer.microsoft.com/windows/downloads/windows-sdk/)（提供 `MakeAppx.exe` / `SignTool.exe`）与 [Go](https://go.dev/dl/)。脚本不接受参数：版本号从 `internal/version.go` 读取，因此本地构建的产物版本始终与源码树一致：
+
+```powershell
+./packaging/msix/make-msix.ps1
+```
+
+产物输出到 `packaging/msix/Output/`；`assets/`、`staging/`、`build/` 为临时目录，均已 gitignore。仅支持不含预发布或构建元数据后缀的正式版本，并会归一化为四段版本号（`1.2.3` → `1.2.3.0`）。

--- a/docs/zh-hans/guides/quick-start.md
+++ b/docs/zh-hans/guides/quick-start.md
@@ -26,6 +26,21 @@ winget install vfox
 前往 [Releases](https://github.com/version-fox/vfox/releases) 页面下载最新版本的 `setup` 安装器，然后按照安装向导进行安装。
 
 </TabItem>
+<TabItem label="MSIX 安装包">
+
+前往 [Releases](https://github.com/version-fox/vfox/releases) 页面下载最新版本的 `.msixbundle` 安装包，然后通过[应用安装程序](https://learn.microsoft.com/windows/msix/app-installer/installing-apps-pkg)或 PowerShell 进行安装：
+
+```powershell
+Add-AppxPackage -Path .\vfox_<version>_windows.msixbundle
+```
+
+安装包会为 `vfox.exe` 注册[应用执行别名](https://learn.microsoft.com/windows/apps/desktop/modernize/desktop-to-uwp-extensions)，因此安装完成后 `vfox` 命令即可直接使用，无需手动配置 PATH。要求 Windows 10（1809+）或 Windows Server 2025 及以上版本。
+
+::: warning ⚠️ 关于未签名包
+目前发布的 `.msixbundle` 安装包是未签名的，Windows 会拒绝安装未签名包。请先使用自己的证书对安装包重新签名，详细步骤参见 [MSIX 安装包](./msix.md)。
+:::
+
+</TabItem>
 </Tabs>
 
 ### Unix-like

--- a/docs/zh-hans/guides/uninstallation.md
+++ b/docs/zh-hans/guides/uninstallation.md
@@ -131,6 +131,16 @@ winget uninstall vfox
 
 :::
 
+::: details MSIX 安装包
+
+```powershell
+Get-AppxPackage *vfox* | Remove-AppxPackage
+```
+
+也可以在 **设置** > **应用** > **已安装的应用** 中选择 **vfox** 并点击 **卸载**。卸载会同时移除 `vfox` 的应用执行别名。
+
+:::
+
 ::: details 手动安装
 
 1. 删除您解压 vfox 的目录

--- a/packaging/msix/AppxManifest.xml
+++ b/packaging/msix/AppxManifest.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  AppxManifest template for the vfox MSIX package.
+
+  Tokens are substituted by msix/make-msix.ps1:
+    @@VERSION@@       four-part package version, e.g. 1.2.3.0
+    @@ARCHITECTURE@@  ProcessorArchitecture: x86 | x64 | arm64
+    @@PUBLISHER@@     must exactly match the subject of the signing certificate
+
+  The windows.appExecutionAlias extension registers `vfox.exe` under
+  %LOCALAPPDATA%\Microsoft\WindowsApps so the CLI is on PATH right after
+  installation without any manual environment changes. It follows the
+  uap5 form recommended by Microsoft's "Packaging a CLI executable as MSIX"
+  guide (the older uap3 form fails schema validation on recent Windows SDKs).
+-->
+<Package
+    xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+    xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+    xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
+    xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+    IgnorableNamespaces="uap5 rescap">
+
+  <Identity
+      Name="VersionFox.vfox"
+      Publisher="@@PUBLISHER@@"
+      Version="@@VERSION@@"
+      ProcessorArchitecture="@@ARCHITECTURE@@" />
+
+  <Properties>
+    <DisplayName>vfox</DisplayName>
+    <PublisherDisplayName>VersionFox</PublisherDisplayName>
+    <Logo>assets\StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26100.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+
+  <Applications>
+    <Application
+        Id="vfox"
+        Executable="vfox.exe"
+        EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements
+          DisplayName="vfox"
+          Description="A cross-platform SDK version manager with a simple cli."
+          BackgroundColor="transparent"
+          Square150x150Logo="assets\Square150x150Logo.png"
+          Square44x44Logo="assets\Square44x44Logo.png">
+        <uap:DefaultTile ShortName="vfox" />
+      </uap:VisualElements>
+      <Extensions>
+        <uap5:Extension Category="windows.appExecutionAlias">
+          <uap5:AppExecutionAlias>
+            <uap5:ExecutionAlias Alias="vfox.exe" />
+          </uap5:AppExecutionAlias>
+        </uap5:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+
+</Package>

--- a/packaging/msix/gen-assets.ps1
+++ b/packaging/msix/gen-assets.ps1
@@ -1,0 +1,129 @@
+#!/usr/bin/env pwsh
+#
+#    Copyright 2026 Han Li and contributors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+<#
+.SYNOPSIS
+    Generates the MSIX tile icons (msix/assets) from the repository logo.
+
+.DESCRIPTION
+    The AppxManifest requires raster PNG logos (SVG is rejected by AppX
+    deployment), but those binaries are not committed: msix/make-msix.ps1 runs
+    this script right before packing, so the icons are always derived from the
+    canonical logo at build time. Transparent margins are cropped away and the
+    artwork is scaled (high-quality bicubic) onto a transparent square canvas.
+
+    Requires Windows (System.Drawing).
+
+.PARAMETER LogoPath
+    Path to the source logo PNG.
+
+.PARAMETER OutDir
+    Output directory for the generated icons.
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$LogoPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+Add-Type -AssemblyName System.Drawing
+
+$targets = @(
+    @{ Name = "Square44x44Logo.png"; Size = 44 },
+    @{ Name = "Square150x150Logo.png"; Size = 150 },
+    @{ Name = "StoreLogo.png"; Size = 50 }
+)
+
+$src = [System.Drawing.Bitmap]::new((Resolve-Path $LogoPath).Path)
+try {
+    # Locate the artwork bounding box via the alpha channel (LockBits: fast).
+    $bounds = [System.Drawing.Rectangle]::new(0, 0, $src.Width, $src.Height)
+    $data = $src.LockBits($bounds, [System.Drawing.Imaging.ImageLockMode]::ReadOnly, [System.Drawing.Imaging.PixelFormat]::Format32bppArgb)
+    try {
+        $minX, $minY, $maxX, $maxY = $src.Width, $src.Height, -1, -1
+        $bytes = New-Object byte[] ($data.Stride * $src.Height)
+        [System.Runtime.InteropServices.Marshal]::Copy($data.Scan0, $bytes, 0, $bytes.Length)
+        for ($y = 0; $y -lt $src.Height; $y++) {
+            $rowBase = $y * $data.Stride
+            for ($x = 0; $x -lt $src.Width; $x++) {
+                if ($bytes[$rowBase + $x * 4 + 3] -gt 8) { # BGRA: alpha at +3
+                    if ($x -lt $minX) { $minX = $x }
+                    if ($y -lt $minY) { $minY = $y }
+                    if ($x -gt $maxX) { $maxX = $x }
+                    if ($y -gt $maxY) { $maxY = $y }
+                }
+            }
+        }
+    }
+    finally {
+        $src.UnlockBits($data)
+    }
+
+    if ($maxX -lt 0) {
+        $crop = $bounds
+    }
+    else {
+        $crop = [System.Drawing.Rectangle]::new($minX, $minY, $maxX - $minX + 1, $maxY - $minY + 1)
+    }
+    Write-Host "source $LogoPath`: canvas $($src.Width)x$($src.Height), content $($crop.Width)x$($crop.Height)"
+
+    New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
+
+    foreach ($target in $targets) {
+        $size = $target.Size
+        $dst = [System.Drawing.Bitmap]::new($size, $size)
+        try {
+            $graphics = [System.Drawing.Graphics]::FromImage($dst)
+            try {
+                $graphics.Clear([System.Drawing.Color]::Transparent)
+                $graphics.InterpolationMode = [System.Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+                $graphics.SmoothingMode = [System.Drawing.Drawing2D.SmoothingMode]::AntiAlias
+                $graphics.PixelOffsetMode = [System.Drawing.Drawing2D.PixelOffsetMode]::HighQuality
+
+                $scale = [Math]::Min($size / $crop.Width, $size / $crop.Height)
+                $width = [Math]::Max(1, [int][Math]::Round($crop.Width * $scale))
+                $height = [Math]::Max(1, [int][Math]::Round($crop.Height * $scale))
+                $offsetX = [int](($size - $width) / 2)
+                $offsetY = [int](($size - $height) / 2)
+
+                # TileFlipXY prevents translucent ghosting from bicubic edge sampling.
+                $attributes = [System.Drawing.Imaging.ImageAttributes]::new()
+                $attributes.SetWrapMode([System.Drawing.Drawing2D.WrapMode]::TileFlipXY)
+
+                $destRect = [System.Drawing.Rectangle]::new($offsetX, $offsetY, $width, $height)
+                $graphics.DrawImage($src, $destRect, $crop.X, $crop.Y, $crop.Width, $crop.Height, [System.Drawing.GraphicsUnit]::Pixel, $attributes)
+            }
+            finally {
+                $graphics.Dispose()
+            }
+            $outPath = Join-Path $OutDir $target.Name
+            $dst.Save($outPath, [System.Drawing.Imaging.ImageFormat]::Png)
+            Write-Host "wrote $outPath ($size x $size)"
+        }
+        finally {
+            $dst.Dispose()
+        }
+    }
+}
+finally {
+    $src.Dispose()
+}

--- a/packaging/msix/make-msix.ps1
+++ b/packaging/msix/make-msix.ps1
@@ -1,0 +1,242 @@
+#!/usr/bin/env pwsh
+#
+#    Copyright 2026 Han Li and contributors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+<#
+.SYNOPSIS
+    Builds vfox from source, packs it into a .msixbundle and optionally signs it.
+
+.DESCRIPTION
+    Requires Windows with the Windows SDK (MakeAppx.exe / SignTool.exe) and Go.
+    Takes no parameters. The version is read from internal/version.go (the
+    single source of truth) and normalized to a four-part MSIX version
+    (1.2.3 -> 1.2.3.0); prerelease or build metadata segments are rejected.
+    Icons are generated from the repository logo, each architecture is built
+    from source and packed into its own .msix rendered from AppxManifest.xml,
+    and all packages are combined into vfox_<version>_windows.msixbundle.
+    The publisher is fixed to "CN=VersionFox". Signing is optional and
+    configured through the environment only:
+      MSIX_SIGN_PFX_PATH (falls back to <script>/signing.pfx when present),
+      MSIX_SIGN_PFX_PASSWORD (falls back to MSIX_PFX_PASSWORD).
+
+.EXAMPLE
+    ./make-msix.ps1
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Assert-NativeSuccess {
+    param([string]$Step)
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Step failed with exit code $LASTEXITCODE"
+    }
+}
+
+function ConvertTo-MsixVersion {
+    param([string]$Raw)
+
+    # Strip a leading 'v'. Prerelease (-rc1) and metadata (+build) segments
+    # cannot be represented in the four-part MSIX version and are rejected.
+    $core = $Raw -replace '^[vV]', ''
+    if ($core -match '[-+]') {
+        throw "Unsupported version '$Raw': MSIX packages require a stable version without prerelease or build metadata."
+    }
+    $parts = @($core -split '\.' | ForEach-Object { [int]$_ })
+    if ($parts.Count -gt 3) {
+        throw "Unsupported version '$Raw': at most three numeric segments are expected"
+    }
+    while ($parts.Count -lt 4) {
+        $parts += 0
+    }
+    return ($parts -join '.')
+}
+
+function Find-SdkTool {
+    param([string]$ToolName)
+
+    $kitsRootEnv = ${env:ProgramFiles(x86)}
+    if ([string]::IsNullOrWhiteSpace($kitsRootEnv)) {
+        throw "Environment variable 'ProgramFiles(x86)' is not set; $ToolName.exe can only be located on Windows with the Windows SDK installed."
+    }
+
+    $kitsRoot = Join-Path $kitsRootEnv "Windows Kits\10\bin"
+    if (-not (Test-Path $kitsRoot)) {
+        throw "Windows SDK not found under '$kitsRoot'. Install the Windows SDK to get $ToolName.exe."
+    }
+
+    $tool = Get-ChildItem -Path $kitsRoot -Directory |
+        Where-Object { $_.Name -match '^\d+(\.\d+)+$' } |
+        Sort-Object { [version]$_.Name } -Descending |
+        ForEach-Object {
+            Get-ChildItem -Path (Join-Path $_.FullName "x64") -Filter "$ToolName.exe" -ErrorAction SilentlyContinue
+        } |
+        Select-Object -First 1
+
+    if ($null -eq $tool) {
+        throw "$ToolName.exe not found under '$kitsRoot'. Install the Windows SDK."
+    }
+    return $tool.FullName
+}
+
+function Invoke-SourceBuild {
+    # Builds vfox.exe for every architecture from the repository source.
+    # Keep the flags aligned with .goreleaser.yaml (CGO_ENABLED=0, -trimpath).
+    # The binary reports the version from internal/version.go; the script
+    # never overrides it, so what you pack is what the source tree says.
+    param([string]$RepoRoot, [string]$BuildDir)
+
+    if ($null -eq (Get-Command "go" -ErrorAction SilentlyContinue)) {
+        throw "'go' is required to build from source but was not found in PATH. Install Go and try again."
+    }
+
+    $archs = @(
+        @{ GoArch = "386";   Name = "x86" },
+        @{ GoArch = "amd64"; Name = "x64" },
+        @{ GoArch = "arm64"; Name = "arm64" }
+    )
+    Push-Location $RepoRoot
+    try {
+        foreach ($a in $archs) {
+            $outDir = Join-Path $BuildDir $a.Name
+            New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+            $env:GOOS = "windows"
+            $env:GOARCH = $a.GoArch
+            $env:CGO_ENABLED = "0"
+            go build -trimpath -ldflags "-s -w" -o (Join-Path $outDir "vfox.exe") .
+            Assert-NativeSuccess -Step "go build ($($a.GoArch))"
+            Write-Host "Built $($a.Name): $(Join-Path $outDir 'vfox.exe')"
+        }
+    }
+    finally {
+        Remove-Item Env:GOOS, Env:GOARCH, Env:CGO_ENABLED -ErrorAction SilentlyContinue
+        Pop-Location
+    }
+}
+
+# Script lives at <repo>/packaging/msix/, so the repository root is two levels up.
+$repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+
+# Single source of truth: the version comes from internal/version.go and is
+# never passed in, so a locally built bundle always matches the source tree.
+$versionFile = Join-Path $repoRoot "internal/version.go"
+$versionMatch = Select-String -Path $versionFile -Pattern '(const|var)\s+RuntimeVersion\s*=\s*"([^"]+)"' | Select-Object -First 1
+if ($null -eq $versionMatch) {
+    throw "RuntimeVersion not found in '$versionFile'."
+}
+$Version = $versionMatch.Matches[0].Groups[2].Value
+$msixVersion = ConvertTo-MsixVersion -Raw $Version
+
+$Publisher = "CN=VersionFox"
+$OutputDir = Join-Path $PSScriptRoot "Output"
+$WorkDir = Join-Path $PSScriptRoot "staging"
+
+# Signing is environment-only. MSIX_SIGN_PFX_PATH falls back to a signing.pfx
+# next to this script (the compile-msix workflow decodes its secret there);
+# the password falls back to MSIX_PFX_PASSWORD (the secret's name).
+$SignPfxPath = $env:MSIX_SIGN_PFX_PATH
+if ([string]::IsNullOrWhiteSpace($SignPfxPath)) {
+    $candidatePfx = Join-Path $PSScriptRoot "signing.pfx"
+    if (Test-Path $candidatePfx) {
+        $SignPfxPath = $candidatePfx
+    }
+}
+$SignPfxPassword = $env:MSIX_SIGN_PFX_PASSWORD
+if ([string]::IsNullOrWhiteSpace($SignPfxPassword)) {
+    $SignPfxPassword = $env:MSIX_PFX_PASSWORD
+}
+
+Write-Host "Building vfox $Version from source..."
+Invoke-SourceBuild -RepoRoot $repoRoot -BuildDir (Join-Path $PSScriptRoot "build")
+$selected = @()
+foreach ($arch in @("x86", "x64", "arm64")) {
+    $selected += @{
+        Architecture = $arch
+        ExePath      = (Resolve-Path (Join-Path $PSScriptRoot "build/$arch/vfox.exe")).Path
+    }
+}
+
+$makeAppx = Find-SdkTool -ToolName "MakeAppx"
+
+# Generate the tile icons from the repository logo (they are not committed).
+& (Join-Path $PSScriptRoot "gen-assets.ps1") `
+    -LogoPath (Join-Path $repoRoot "logo.png") `
+    -OutDir (Join-Path $PSScriptRoot "assets")
+
+New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+New-Item -ItemType Directory -Path $WorkDir -Force | Out-Null
+
+$manifestTemplate = Get-Content -Raw -Path (Join-Path $PSScriptRoot "AppxManifest.xml")
+$assetsDir = Join-Path $PSScriptRoot "assets"
+if (-not (Test-Path $assetsDir)) {
+    throw "Assets directory not found: $assetsDir"
+}
+
+$packages = @()
+foreach ($entry in $selected) {
+    $arch = $entry.Architecture
+    $stage = Join-Path $WorkDir $arch
+    if (Test-Path $stage) {
+        Remove-Item -Path $stage -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $stage -Force | Out-Null
+
+    Copy-Item -Path $entry.ExePath -Destination (Join-Path $stage "vfox.exe")
+    Copy-Item -Path $assetsDir -Destination (Join-Path $stage "assets") -Recurse
+
+    $manifest = $manifestTemplate
+    $manifest = $manifest.Replace("@@VERSION@@", $msixVersion)
+    $manifest = $manifest.Replace("@@ARCHITECTURE@@", $arch)
+    # Escape XML entities in the fixed publisher value before token replacement.
+    $manifest = $manifest.Replace("@@PUBLISHER@@", [System.Security.SecurityElement]::Escape($Publisher))
+    Set-Content -Path (Join-Path $stage "AppxManifest.xml") -Value $manifest -Encoding UTF8 -NoNewline
+
+    $packagePath = Join-Path $OutputDir ("vfox_{0}_windows_{1}.msix" -f $Version, $arch)
+    & $makeAppx pack /o /d $stage /p $packagePath | Out-Host
+    Assert-NativeSuccess -Step "MakeAppx pack ($arch)"
+
+    $packages += $packagePath
+    Write-Host "Created package: $packagePath"
+}
+
+$bundleStage = Join-Path $WorkDir "bundle"
+if (Test-Path $bundleStage) {
+    Remove-Item -Path $bundleStage -Recurse -Force
+}
+New-Item -ItemType Directory -Path $bundleStage -Force | Out-Null
+foreach ($pkg in $packages) {
+    Copy-Item -Path $pkg -Destination $bundleStage
+}
+
+$bundlePath = Join-Path $OutputDir ("vfox_{0}_windows.msixbundle" -f $Version)
+& $makeAppx bundle /o /d $bundleStage /p $bundlePath | Out-Host
+Assert-NativeSuccess -Step "MakeAppx bundle"
+Write-Host "Created bundle: $bundlePath"
+
+if (-not [string]::IsNullOrWhiteSpace($SignPfxPath)) {
+    if ([string]::IsNullOrWhiteSpace($SignPfxPassword)) {
+        throw "A signing certificate was found but no password was provided. Set MSIX_SIGN_PFX_PASSWORD (or MSIX_PFX_PASSWORD)."
+    }
+    $signTool = Find-SdkTool -ToolName "signtool"
+    & $signTool sign /fd SHA256 /f $SignPfxPath /p $SignPfxPassword $bundlePath | Out-Host
+    Assert-NativeSuccess -Step "SignTool sign"
+    Write-Host "Signed bundle: $bundlePath"
+}
+else {
+    Write-Warning "No signing certificate provided; publishing UNSIGNED bundle. Windows blocks installation of unsigned packages unless they are re-signed first."
+}
+
+Write-Host "`nArtifacts:"
+Get-ChildItem -Path $OutputDir | Format-Table Name, Length -AutoSize | Out-Host

--- a/scripts/e2e-msix-test.ps1
+++ b/scripts/e2e-msix-test.ps1
@@ -1,0 +1,345 @@
+#!/usr/bin/env pwsh
+
+#    Copyright 2026 Han Li and contributors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+<#
+.SYNOPSIS
+    Integration tests for the vfox MSIX packaging pipeline.
+
+.DESCRIPTION
+    Must run on Windows (Windows 10 1809+ / Windows Server 2025 or newer).
+    Builds vfox.exe for x86/x64/arm64, packs them into an .msixbundle via
+    msix/make-msix.ps1, signs it with an ephemeral self-signed certificate,
+    installs the bundle through the AppX deployment service, verifies the
+    `vfox` CLI through its app execution alias, then uninstalls it.
+
+.PARAMETER OutputDir
+    Directory for artifacts (packages, logs). Defaults to <repo>/msix-e2e-out.
+#>
+
+param(
+    [string]$OutputDir = (Join-Path (Split-Path $PSScriptRoot -Parent) "msix-e2e-out")
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$GREEN = "`e[32m"
+$RED = "`e[31m"
+$YELLOW = "`e[33m"
+$NC = "`e[0m"
+
+$RepoRoot = Split-Path $PSScriptRoot -Parent
+$TestVersion = "9.9.9"
+$PfxPassword = "vfox-e2e-password"
+$PublisherSubject = "CN=VersionFox"
+$PackageIdentityName = "VersionFox.vfox"
+
+$TEST_COUNT = 0
+$PASSED = 0
+$FAILED = 0
+
+$InstalledPackage = $null
+$E2ECert = $null
+$pfxPath = $null
+
+# make-msix.ps1 takes no parameters and reads its version from
+# internal/version.go, so the e2e run temporarily points the source tree at
+# the throwaway test version. The original content is restored in finally.
+$versionFile = Join-Path $RepoRoot "internal/version.go"
+$originalVersionGo = $null
+$versionPatched = $false
+$msixOutDir = Join-Path $RepoRoot "packaging/msix/Output"
+
+function Write-Banner {
+    param([string]$Title, [ConsoleColor]$Color = [ConsoleColor]::White)
+    $bar = "=" * 42
+    Write-Host ""
+    Write-Host $bar
+    Write-Host $Title -ForegroundColor $Color
+    Write-Host $bar
+}
+
+Write-Banner "vFox MSIX Packaging E2E Test" Cyan
+
+function Run-Test {
+    param(
+        [string]$TestName,
+        [scriptblock]$TestScript,
+        [string]$ExpectedOutput
+    )
+
+    $script:TEST_COUNT++
+
+    Write-Host "`nTest $($script:TEST_COUNT): $TestName" -ForegroundColor Yellow
+    Write-Host "Running test..."
+
+    try {
+        $result = & $TestScript 2>&1 | Out-String
+
+        if ($result -match [regex]::Escape($ExpectedOutput)) {
+            Write-Host "$GREEN✓ PASSED$NC" -ForegroundColor Green
+            $script:PASSED++
+        }
+        else {
+            Write-Host "$RED✗ FAILED$NC" -ForegroundColor Red
+            Write-Host "Expected: $ExpectedOutput"
+            Write-Host "Got: $result"
+            $script:FAILED++
+        }
+    }
+    catch {
+        Write-Host "$RED✗ FAILED$NC" -ForegroundColor Red
+        Write-Host "Error: $_"
+        $script:FAILED++
+    }
+}
+
+try {
+    # Export-PfxCertificate requires the target directory to exist.
+    New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+
+    # Fail fast instead of clobbering an existing installation: cleanup only
+    # removes what this run installs.
+    if ($null -ne (Get-AppxPackage -Name $PackageIdentityName -ErrorAction SilentlyContinue)) {
+        throw "A package with identity '$PackageIdentityName' is already installed. Uninstall it first to avoid clobbering your installation."
+    }
+
+    # ------------------------------------------------------------------
+    # Step 1: Create ephemeral code-signing certificate
+    # ------------------------------------------------------------------
+    Write-Banner "Step 1: Creating self-signed certificate"
+
+    $E2ECert = New-SelfSignedCertificate -Type Custom `
+        -Subject $PublisherSubject `
+        -KeyUsage DigitalSignature `
+        -FriendlyName "vfox MSIX E2E (ephemeral)" `
+        -CertStoreLocation "Cert:\CurrentUser\My" `
+        -NotAfter (Get-Date).AddDays(3) `
+        -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")
+
+    # Keep the PFX (private key) outside of $OutputDir: that directory is
+    # uploaded as a CI artifact and must never contain signing material.
+    $tempRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+    $pfxPath = Join-Path $tempRoot "vfox-e2e-$PID.pfx"
+    $securePassword = ConvertTo-SecureString -String $PfxPassword -Force -AsPlainText
+    Export-PfxCertificate -Cert $E2ECert -FilePath $pfxPath -Password $securePassword | Out-Null
+    Write-Host "Certificate created: $($E2ECert.Thumbprint)" -ForegroundColor Green
+
+    # ------------------------------------------------------------------
+    # Step 2: Build + pack + sign the bundle
+    # ------------------------------------------------------------------
+    Write-Banner "Step 2: Building and packing MSIX bundle"
+
+    $packageDir = Join-Path $OutputDir "packages"
+    New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
+
+    # Point the source tree at the throwaway test version so the bundle (and
+    # the binary inside it) reports 9.9.9 instead of the real release version.
+    # This also keeps the test isolated from any vfox already installed.
+    $originalVersionGo = Get-Content -Raw -Path $versionFile
+    if ($originalVersionGo -notmatch '\b(var|const)\s+RuntimeVersion\s*=') {
+        throw "RuntimeVersion not found in $versionFile"
+    }
+    $patchedVersionGo = $originalVersionGo -replace '\b(var|const)\s+RuntimeVersion\s*=\s*"[^"]*"', ('var RuntimeVersion = "{0}"' -f $TestVersion)
+    Set-Content -Path $versionFile -Value $patchedVersionGo -Encoding UTF8 -NoNewline
+    $versionPatched = $true
+    Write-Host "Patched $versionFile to test version $TestVersion"
+
+    # make-msix.ps1 takes no parameters: version comes from the patched source
+    # above, signing inputs come from the environment.
+    $env:MSIX_SIGN_PFX_PATH = $pfxPath
+    $env:MSIX_SIGN_PFX_PASSWORD = $PfxPassword
+    try {
+        & (Join-Path $RepoRoot "packaging/msix/make-msix.ps1")
+        if ($LASTEXITCODE -ne 0) {
+            throw "make-msix.ps1 failed with exit code $LASTEXITCODE"
+        }
+    }
+    finally {
+        Remove-Item Env:MSIX_SIGN_PFX_PATH -ErrorAction SilentlyContinue
+        Remove-Item Env:MSIX_SIGN_PFX_PASSWORD -ErrorAction SilentlyContinue
+    }
+
+    $bundlePath = Join-Path $msixOutDir ("vfox_{0}_windows.msixbundle" -f $TestVersion)
+    if (-not (Test-Path $bundlePath)) {
+        throw "Bundle not found: $bundlePath"
+    }
+    # Copy the bundle into the e2e output directory: $OutputDir is uploaded as
+    # a CI artifact, while packaging/msix/Output is a gitignored scratch dir.
+    Copy-Item -Path $bundlePath -Destination (Join-Path $packageDir (Split-Path $bundlePath -Leaf))
+
+    # ------------------------------------------------------------------
+    # Step 3: Trust certificate and install the bundle
+    # ------------------------------------------------------------------
+    Write-Banner "Step 3: Installing MSIX bundle"
+
+    $trustedPeople = "Cert:\LocalMachine\TrustedPeople"
+    Import-PfxCertificate -FilePath $pfxPath -CertStoreLocation $trustedPeople -Password $securePassword | Out-Null
+    Write-Host "Certificate imported into TrustedPeople"
+
+    Add-AppxPackage -Path $bundlePath
+    $InstalledPackage = Get-AppxPackage -Name $PackageIdentityName
+    if ($null -eq $InstalledPackage) {
+        throw "Package was not registered after Add-AppxPackage"
+    }
+    Write-Host "Installed: $($InstalledPackage.PackageFullName)" -ForegroundColor Green
+
+    # ------------------------------------------------------------------
+    # Step 4: Assertions
+    # ------------------------------------------------------------------
+    $aliasPath = Join-Path $env:LOCALAPPDATA "Microsoft\WindowsApps\vfox.exe"
+
+    Run-Test "Per-architecture packages were produced" `
+        {
+            $missing = @(@("x86", "x64", "arm64") |
+                ForEach-Object { Join-Path $msixOutDir "vfox_${TestVersion}_windows_$_.msix" } |
+                Where-Object { -not (Test-Path $_) })
+            if ($missing.Count -gt 0) {
+                "MISSING: $($missing -join ', ')"
+            }
+            elseif (-not (Test-Path $bundlePath)) { "MISSING_BUNDLE" }
+            else { "ALL_PACKAGES_PRESENT" }
+        } `
+        "ALL_PACKAGES_PRESENT"
+
+    Run-Test "Package registered with normalized version" `
+        {
+            $pkg = Get-AppxPackage -Name $PackageIdentityName
+            if ($null -eq $pkg) { "PACKAGE_NOT_FOUND" }
+            elseif ($pkg.Version -eq "$TestVersion.0" -and $pkg.Publisher -eq $PublisherSubject) {
+                "VERSION_OK"
+            }
+            else { "UNEXPECTED: $($pkg.Version) / $($pkg.Publisher)" }
+        } `
+        "VERSION_OK"
+
+    Run-Test "App execution alias exists" `
+        {
+            $deadline = (Get-Date).AddSeconds(30)
+            while (-not (Test-Path $aliasPath) -and (Get-Date) -lt $deadline) {
+                Start-Sleep -Milliseconds 500
+            }
+            if (Test-Path $aliasPath) { "ALIAS_EXISTS" } else { "ALIAS_MISSING" }
+        } `
+        "ALIAS_EXISTS"
+
+    Run-Test "vfox runs through execution alias" `
+        {
+            $versionOutput = & $aliasPath --version 2>&1 | Out-String
+            if ($versionOutput -match '\d+\.\d+\.\d+') { "CLI_OK: $($versionOutput.Trim())" } else { "BAD_OUTPUT: $versionOutput" }
+        } `
+        "CLI_OK"
+
+    Run-Test "vfox --help through execution alias" `
+        {
+            $helpOutput = & $aliasPath --help 2>&1 | Out-String
+            if ($helpOutput -match 'Usage') { "HELP_OK" } else { "BAD_OUTPUT: $helpOutput" }
+        } `
+        "HELP_OK"
+
+    Run-Test "Packaged binary keeps user data outside WindowsApps" `
+        {
+            $tempRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+            $probeHome = Join-Path $tempRoot "vfox-msix-probe-home"
+            New-Item -ItemType Directory -Path $probeHome -Force | Out-Null
+            $originalProfile = $env:USERPROFILE
+            $env:USERPROFILE = $probeHome
+            try {
+                # `list` initializes SdkManager/pathmeta (unlike --version/--help,
+                # which are handled at CLI routing), so ~/.vfox gets created.
+                $null = & $aliasPath list 2>&1
+                if (Test-Path (Join-Path $probeHome ".vfox")) { "USER_DATA_OK" } else { "NO_USER_DATA" }
+            }
+            finally {
+                $env:USERPROFILE = $originalProfile
+                Remove-Item -Path $probeHome -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        } `
+        "USER_DATA_OK"
+
+    # ------------------------------------------------------------------
+    # Step 5: Uninstall
+    # ------------------------------------------------------------------
+    Write-Banner "Step 5: Uninstalling MSIX bundle"
+
+    Run-Test "Uninstall removes the package and alias" `
+        {
+            $pkg = Get-AppxPackage -Name $PackageIdentityName
+            if ($null -eq $pkg) { return "PACKAGE_NOT_FOUND_BEFORE_UNINSTALL" }
+            Remove-AppxPackage -Package $pkg.PackageFullName
+            $script:InstalledPackage = $null
+            $deadline = (Get-Date).AddSeconds(30)
+            while ((Get-AppxPackage -Name $PackageIdentityName) -and (Get-Date) -lt $deadline) {
+                Start-Sleep -Milliseconds 500
+            }
+            if ((Get-AppxPackage -Name $PackageIdentityName)) { return "PACKAGE_STILL_REGISTERED" }
+            if (Test-Path $aliasPath) { return "ALIAS_STILL_EXISTS" }
+            return "UNINSTALL_OK"
+        } `
+        "UNINSTALL_OK"
+}
+catch {
+    Write-Host "`n$RED✗ Fatal error: $_$NC" -ForegroundColor Red
+    $script:FAILED++
+}
+finally {
+    Write-Banner "Cleanup"
+
+    # Restore the source tree first so a failed run never leaves the
+    # throwaway test version behind.
+    if ($versionPatched -and $null -ne $originalVersionGo) {
+        Set-Content -Path $versionFile -Value $originalVersionGo -Encoding UTF8 -NoNewline
+        Write-Host "Restored $versionFile" -ForegroundColor Yellow
+    }
+    Remove-Item Env:MSIX_SIGN_PFX_PATH -ErrorAction SilentlyContinue
+    Remove-Item Env:MSIX_SIGN_PFX_PASSWORD -ErrorAction SilentlyContinue
+    # Remove the throwaway test artifacts from the packaging scratch dir
+    # (the copies under $OutputDir are kept for the CI artifact upload).
+    if ($null -ne $msixOutDir -and (Test-Path $msixOutDir)) {
+        Get-ChildItem -Path $msixOutDir -Filter ("vfox_{0}_windows*" -f $TestVersion) -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+    }
+
+    # Only remove the package installed by this run (exact identity), never
+    # an unrelated package that happens to match a wildcard.
+    if ($null -ne $InstalledPackage) {
+        Remove-AppxPackage -Package $InstalledPackage.PackageFullName -ErrorAction SilentlyContinue
+        Write-Host "Removed leftover AppX package" -ForegroundColor Yellow
+    }
+    if ($null -ne $E2ECert) {
+        Remove-Item -Path "Cert:\CurrentUser\My\$($E2ECert.Thumbprint)" -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path "Cert:\LocalMachine\TrustedPeople\$($E2ECert.Thumbprint)" -Force -ErrorAction SilentlyContinue
+        Write-Host "Removed ephemeral certificate" -ForegroundColor Yellow
+    }
+    if ($null -ne $pfxPath -and (Test-Path $pfxPath)) {
+        Remove-Item -Path $pfxPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# Print summary
+Write-Banner "Test Summary"
+Write-Host "Total tests: $($script:TEST_COUNT)"
+Write-Host "Passed: $($script:PASSED)" -ForegroundColor Green
+Write-Host "Failed: $($script:FAILED)" -ForegroundColor Red
+
+if ($script:FAILED -eq 0) {
+    Write-Host "`nAll tests passed! ✓" -ForegroundColor Green
+    exit 0
+}
+else {
+    Write-Host "`nSome tests failed! ✗" -ForegroundColor Red
+    exit 1
+}


### PR DESCRIPTION
- Fixes #682 .
- Add Windows installation packages in `.msixbundle` format.
- Verified as valid via the CI runs at https://github.com/linghengqian/vfox/actions/runs/32502640872 and https://github.com/linghengqian/vfox/actions/runs/32502640828 .
- I am unsure whether `AGENTS.md` should be updated, but leaving it unchanged might lead to misunderstandings.